### PR TITLE
fix: invalid regular exp on windows

### DIFF
--- a/gridsome/lib/server/createExpressServer.js
+++ b/gridsome/lib/server/createExpressServer.js
@@ -22,7 +22,7 @@ module.exports = async app => {
   )
 
   const assetsDir = path.relative(config.targetDir, config.assetsDir)
-  const route = path.join(config.pathPrefix, assetsDir, 'static', '*')
+  const route = path.posix.join(config.pathPrefix, assetsDir, 'static', '*')
   server.get(forwardSlash(route), require('./middlewares/assets')(app))
 
   const createUrl = (endpoint, protocol = 'http') => {


### PR DESCRIPTION
fixes #11 

for now we don't need to replace all the backslash to slash