### PR TITLE
Updated for image support

### DIFF
--- a/packages/source-wordpress/index.js
+++ b/packages/source-wordpress/index.js
@@ -114,7 +114,8 @@ class WordPressSource {
           slug: post.slug,
           fields: {
             content: post.content ? post.content.rendered : '',
-            excerpt: post.excerpt ? post.excerpt.rendered : ''
+            excerpt: post.excerpt ? post.excerpt.rendered : '',
+            betterFeaturedImage: post.better_featured_image ? post.better_featured_image.source_url : ''
           },
           refs
         })


### PR DESCRIPTION
This adds the better_featured_image endpoint to GraphQL and the only requirement is that the Wordpress install has the Better REST API Featured Images Plugin https://wordpress.org/plugins/better-rest-api-featured-images/ To add native support for images without this plugin "?_embed" would need to appended to the end of each URL.