### PR TITLE
Resolve file paths in node fields

### DIFF
--- a/gridsome/__tests__/PluginStore.spec.js
+++ b/gridsome/__tests__/PluginStore.spec.js
@@ -152,9 +152,15 @@ test('transform node', () => {
 })
 
 test('resolve absolute file paths', () => {
-  const contentType1 = api.store.addContentType({ typeName: 'A', fileBasePath: 'file' })
-  const contentType2 = api.store.addContentType({ typeName: 'B', fileBasePath: 'root' })
-  const contentType3 = api.store.addContentType({ typeName: 'C', fileBasePath: '/path/to/dir' })
+  const contentType1 = api.store.addContentType({
+    typeName: 'A',
+    resolveAbsolutePaths: true
+  })
+
+  const contentType2 = api.store.addContentType({
+    typeName: 'C',
+    resolveAbsolutePaths: '/path/to/dir'
+  })
 
   const node1 = contentType1.addNode({
     fields: {
@@ -180,33 +186,23 @@ test('resolve absolute file paths', () => {
     }
   })
 
-  const node3 = contentType3.addNode({
-    fields: {
-      file: '/image.png'
-    },
-    internal: {
-      origin: '/absolute/dir/to/a/file.md'
-    }
-  })
-
   expect(node1.fields.file).toEqual('/absolute/dir/to/a/image.png')
-  expect(node1.fields.file2).toEqual('/absolute/dir/to/a/image.png')
+  expect(node1.fields.file2).toEqual('/image.png')
   expect(node1.fields.file3).toEqual('/absolute/dir/to/image.png')
   expect(node1.fields.text).toEqual('Lorem ipsum dolor sit amet.')
   expect(node1.fields.text2).toEqual('example.com')
   expect(node1.fields.image).toEqual('https://example.com/image.jpg')
   expect(node1.fields.image2).toEqual('//example.com/image.jpg')
-  expect(node2.fields.file).toEqual('/image.png')
-  expect(node3.fields.file).toEqual('/path/to/dir/image.png')
+  expect(node2.fields.file).toEqual('/path/to/dir/image.png')
 })
 
-test('don\'t touch paths when fileBasePath is not set', () => {
+test('don\'t touch absolute paths when resolveAbsolutePaths is not set', () => {
   const contentType = api.store.addContentType({ typeName: 'A' })
 
   const node = contentType.addNode({
     fields: {
-      file: 'image.png',
-      file2: '/image.png',
+      file: '/image.png',
+      file2: 'image.png',
       file3: '../image.png'
     },
     internal: {
@@ -214,8 +210,8 @@ test('don\'t touch paths when fileBasePath is not set', () => {
     }
   })
 
-  expect(node.fields.file).toEqual('image.png')
-  expect(node.fields.file2).toEqual('/image.png')
+  expect(node.fields.file).toEqual('/image.png')
+  expect(node.fields.file2).toEqual('/absolute/dir/to/a/image.png')
   expect(node.fields.file3).toEqual('/absolute/dir/to/image.png')
 })
 
@@ -235,20 +231,13 @@ test('always resolve relative paths from filesytem sources', () => {
 })
 
 test('resolve paths from external sources', () => {
-  const contentType1 = api.store.addContentType({
-    typeName: 'A',
-    fileBasePath: 'path'
-  })
-
-  const contentType2 = api.store.addContentType({
-    typeName: 'B',
-    fileBasePath: 'host'
-  })
+  const contentType1 = api.store.addContentType({ typeName: 'A' })
+  const contentType2 = api.store.addContentType({ typeName: 'B', resolveAbsolutePaths: true })
 
   const node1 = contentType1.addNode({
     fields: {
-      file: 'image.png',
-      file2: '/image.png',
+      file: '/image.png',
+      file2: 'image.png',
       file3: '../../image.png'
     },
     internal: {
@@ -267,12 +256,12 @@ test('resolve paths from external sources', () => {
     }
   })
 
-  expect(node1.fields.file).toEqual('https://example.com/2018/11/02/image.png')
+  expect(node1.fields.file).toEqual('/image.png')
   expect(node1.fields.file2).toEqual('https://example.com/2018/11/02/image.png')
   expect(node1.fields.file3).toEqual('https://example.com/2018/image.png')
-  expect(node2.fields.file).toEqual('https://example.com/images/image.png')
+  expect(node2.fields.file).toEqual('https://example.com/2018/11/02/images/image.png')
   expect(node2.fields.file2).toEqual('https://example.com/images/image.png')
-  expect(node2.fields.file3).toEqual('https://example.com/images/image.png')
+  expect(node2.fields.file3).toEqual('https://example.com/2018/11/02/images/image.png')
 })
 
 test('fail if transformer is not installed', () => {

--- a/gridsome/__tests__/PluginStore.spec.js
+++ b/gridsome/__tests__/PluginStore.spec.js
@@ -173,8 +173,11 @@ test('resolve absolute file paths', () => {
       file: 'image.png',
       file2: '/image.png',
       file3: '../image.png',
-      image: 'https://example.com/image.jpg',
-      image2: '//example.com/image.jpg',
+      url: 'https://example.com/image.jpg',
+      url2: '//example.com/image.jpg',
+      url3: 'git@github.com:gridsome/gridsome.git',
+      url4: 'ftp://ftp.example.com',
+      email: 'email@example.com',
       text: 'Lorem ipsum dolor sit amet.',
       text2: 'example.com'
     },
@@ -188,8 +191,11 @@ test('resolve absolute file paths', () => {
   expect(node.fields.file3).toEqual('/absolute/dir/to/image.png')
   expect(node.fields.text).toEqual('Lorem ipsum dolor sit amet.')
   expect(node.fields.text2).toEqual('example.com')
-  expect(node.fields.image).toEqual('https://example.com/image.jpg')
-  expect(node.fields.image2).toEqual('//example.com/image.jpg')
+  expect(node.fields.url).toEqual('https://example.com/image.jpg')
+  expect(node.fields.url2).toEqual('//example.com/image.jpg')
+  expect(node.fields.url3).toEqual('git@github.com:gridsome/gridsome.git')
+  expect(node.fields.url4).toEqual('ftp://ftp.example.com')
+  expect(node.fields.email).toEqual('email@example.com')
 })
 
 test('resolve absolute file paths with a custom path', () => {

--- a/gridsome/__tests__/PluginStore.spec.js
+++ b/gridsome/__tests__/PluginStore.spec.js
@@ -2,11 +2,9 @@ const App = require('../lib/app/App')
 const PluginAPI = require('../lib/app/PluginAPI')
 const JSONTransformer = require('./__fixtures__/JSONTransformer')
 
-let app, api
-
-beforeEach(() => {
-  app = new App('/', { config: { plugins: [] }}).init()
-  api = new PluginAPI(app, {
+function createPlugin (context = '/') {
+  const app = new App(context, { config: { plugins: [] }}).init()
+  const api = new PluginAPI(app, {
     entry: { options: {}, clientOptions: undefined },
     transformers: {
       'application/json': {
@@ -16,14 +14,13 @@ beforeEach(() => {
       }
     }
   })
-})
 
-afterAll(() => {
-  app = null
-  api = null
-})
+  return api
+}
 
 test('add type', () => {
+  const api = createPlugin()
+
   const contentType = api.store.addContentType({
     typeName: 'TestPost'
   })
@@ -34,6 +31,8 @@ test('add type', () => {
 })
 
 test('add node', () => {
+  const api = createPlugin()
+
   const contentType = api.store.addContentType({
     typeName: 'TestPost'
   })
@@ -58,6 +57,8 @@ test('add node', () => {
 })
 
 test('update node', () => {
+  const api = createPlugin()
+
   const contentType = api.store.addContentType({
     typeName: 'TestPost'
   })
@@ -87,6 +88,8 @@ test('update node', () => {
 })
 
 test('remove node', () => {
+  const api = createPlugin()
+
   const contentType = api.store.addContentType({
     typeName: 'TestPost'
   })
@@ -103,6 +106,8 @@ test('remove node', () => {
 })
 
 test('add type with ref', () => {
+  const api = createPlugin()
+
   const contentType = api.store.addContentType({
     typeName: 'TestPost',
     refs: {
@@ -122,6 +127,8 @@ test('add type with ref', () => {
 })
 
 test('add type with dynamic route', () => {
+  const api = createPlugin()
+
   const contentType = api.store.addContentType({
     typeName: 'TestPost',
     route: ':year/:month/:day/:slug'
@@ -137,6 +144,8 @@ test('add type with dynamic route', () => {
 })
 
 test('transform node', () => {
+  const api = createPlugin()
+
   const contentType = api.store.addContentType({
     typeName: 'TestPost'
   })
@@ -152,6 +161,8 @@ test('transform node', () => {
 })
 
 test('resolve absolute file paths', () => {
+  const api = createPlugin('/absolute/dir/to/project')
+
   const contentType1 = api.store.addContentType({
     typeName: 'A',
     resolveAbsolutePaths: true
@@ -187,7 +198,7 @@ test('resolve absolute file paths', () => {
   })
 
   expect(node1.fields.file).toEqual('/absolute/dir/to/a/image.png')
-  expect(node1.fields.file2).toEqual('/image.png')
+  expect(node1.fields.file2).toEqual('/absolute/dir/to/project/image.png')
   expect(node1.fields.file3).toEqual('/absolute/dir/to/image.png')
   expect(node1.fields.text).toEqual('Lorem ipsum dolor sit amet.')
   expect(node1.fields.text2).toEqual('example.com')
@@ -197,6 +208,8 @@ test('resolve absolute file paths', () => {
 })
 
 test('don\'t touch absolute paths when resolveAbsolutePaths is not set', () => {
+  const api = createPlugin('/absolute/dir/to/project')
+
   const contentType = api.store.addContentType({ typeName: 'A' })
 
   const node = contentType.addNode({
@@ -216,6 +229,8 @@ test('don\'t touch absolute paths when resolveAbsolutePaths is not set', () => {
 })
 
 test('always resolve relative paths from filesytem sources', () => {
+  const api = createPlugin()
+
   const contentType = api.store.addContentType({ typeName: 'A' })
 
   const node = contentType.addNode({
@@ -231,6 +246,8 @@ test('always resolve relative paths from filesytem sources', () => {
 })
 
 test('resolve paths from external sources', () => {
+  const api = createPlugin()
+
   const contentType1 = api.store.addContentType({ typeName: 'A' })
   const contentType2 = api.store.addContentType({ typeName: 'B', resolveAbsolutePaths: true })
 
@@ -265,6 +282,8 @@ test('resolve paths from external sources', () => {
 })
 
 test('fail if transformer is not installed', () => {
+  const api = createPlugin()
+
   const contentType = api.store.addContentType({
     typeName: 'TestPost'
   })
@@ -280,6 +299,8 @@ test('fail if transformer is not installed', () => {
 })
 
 test('generate slug from any string', () => {
+  const api = createPlugin()
+
   const slug1 = api.store.slugify('Lorem ipsum dolor sit amet')
   const slug2 = api.store.slugify('String with æøå characters')
   const slug3 = api.store.slugify('String/with / slashes')
@@ -292,6 +313,8 @@ test('generate slug from any string', () => {
 })
 
 test('add page', () => {
+  const api = createPlugin()
+
   const emit = jest.spyOn(api.store, 'emit')
   const page = api.store.addPage('page', {
     title: 'Lorem ipsum dolor sit amet',
@@ -311,6 +334,8 @@ test('add page', () => {
 })
 
 test('add page with query', () => {
+  const api = createPlugin()
+
   const page = api.store.addPage('page', {
     pageQuery: {
       content: 'query Test { page { _id } }',
@@ -330,6 +355,8 @@ test('add page with query', () => {
 })
 
 test('update page', () => {
+  const api = createPlugin()
+
   api.store.addPage('page', {
     _id: 'test',
     title: 'Lorem ipsum dolor sit amet',
@@ -352,6 +379,8 @@ test('update page', () => {
 })
 
 test('update page path when slug is changed', () => {
+  const api = createPlugin()
+
   api.store.addPage('page', { _id: 'test' })
 
   const page = api.store.updatePage('test', {
@@ -364,6 +393,8 @@ test('update page path when slug is changed', () => {
 })
 
 test('remove page', () => {
+  const api = createPlugin()
+
   const emit = jest.spyOn(api.store, 'emit')
 
   api.store.addPage('page', { _id: 'test' })

--- a/gridsome/__tests__/__fixtures__/JSONTransformer.js
+++ b/gridsome/__tests__/__fixtures__/JSONTransformer.js
@@ -1,0 +1,35 @@
+const { GraphQLString } = require('../../graphql')
+
+class JSONTransformer {
+  static mimeTypes () {
+    return ['application/json']
+  }
+
+  constructor (options, { resolveNodeFilePath }) {
+    this.resolveNodeFilePath = resolveNodeFilePath
+  }
+
+  parse (content) {
+    return {
+      fields: JSON.parse(content)
+    }
+  }
+
+  extendNodeType () {
+    return {
+      myField: {
+        type: GraphQLString,
+        resolve: () => 'value'
+      },
+      fileField: {
+        type: GraphQLString,
+        resolve: node => {
+          // return this.resolveNodeFilePath(node, './file.md')
+          return './file.md'
+        }
+      }
+    }
+  }
+}
+
+module.exports = JSONTransformer

--- a/gridsome/__tests__/__fixtures__/JSONTransformer.js
+++ b/gridsome/__tests__/__fixtures__/JSONTransformer.js
@@ -24,8 +24,7 @@ class JSONTransformer {
       fileField: {
         type: GraphQLString,
         resolve: node => {
-          // return this.resolveNodeFilePath(node, './file.md')
-          return './file.md'
+          return this.resolveNodeFilePath(node, './image.png')
         }
       }
     }

--- a/gridsome/__tests__/schema.spec.js
+++ b/gridsome/__tests__/schema.spec.js
@@ -3,6 +3,7 @@ const PluginAPI = require('../lib/app/PluginAPI')
 const createSchema = require('../lib/graphql/createSchema')
 const { inferTypes } = require('../lib/graphql/schema/infer-types')
 const { GraphQLDate } = require('../lib/graphql/schema/types/date')
+const JSONTransformer = require('./__fixtures__/JSONTransformer')
 
 const {
   graphql,
@@ -16,25 +17,18 @@ const {
 
 let app, api
 
-const transformers = {
-  'application/json': {
-    extendNodeType () {
-      return {
-        myField: {
-          type: GraphQLString,
-          resolve: () => 'value'
-        }
+beforeEach(() => {
+  app = new App('/', { config: { plugins: [] }}).init()
+  api = new PluginAPI(app, {
+    entry: { options: {}, clientOptions: undefined },
+    transformers: {
+      'application/json': {
+        TransformerClass: JSONTransformer,
+        options: {},
+        name: 'json'
       }
     }
-  }
-}
-
-beforeEach(() => {
-  const entry = { options: {}, clientOptions: undefined }
-
-  app = new App('/', { config: { plugins: [] }})
-  app.init()
-  api = new PluginAPI(app, { entry, transformers })
+  })
 })
 
 afterAll(() => {

--- a/gridsome/lib/app/App.js
+++ b/gridsome/lib/app/App.js
@@ -157,17 +157,10 @@ class App {
     return path.resolve(this.context, p)
   }
 
-  resolveFilePath (fromPath, toPath, from = '') {
-    return resolvePath(fromPath, toPath, from, {
+  resolveFilePath (fromPath, toPath, isAbsolute) {
+    return resolvePath(fromPath, toPath, isAbsolute, {
       context: this.context
     })
-  }
-
-  resolveNodeFilePath (node, toPath) {
-    const { getContentType } = this._app.store
-    const { collection: { fileBasePath } } = getContentType(node.typeName)
-
-    return app.resolveFilePath(node.internal.origin, toPath, fileBasePath)
   }
 
   graphql (docOrQuery, variables = {}) {

--- a/gridsome/lib/app/App.js
+++ b/gridsome/lib/app/App.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const isUrl = require('is-url')
 const Router = require('vue-router')
 const autoBind = require('auto-bind')
 const hirestime = require('hirestime')
@@ -12,7 +13,7 @@ const { defaultsDeep } = require('lodash')
 const createRoutes = require('./createRoutes')
 const { execute, graphql } = require('../graphql/graphql')
 const { version } = require('../../package.json')
-const { resolvePath } = require('../utils')
+const { parseUrl, resolvePath } = require('../utils')
 
 class App {
   constructor (context, options) {
@@ -158,9 +159,21 @@ class App {
   }
 
   resolveFilePath (fromPath, toPath, isAbsolute) {
-    return resolvePath(fromPath, toPath, isAbsolute, {
-      context: this.context
-    })
+    let rootDir = null
+
+    if (typeof isAbsolute === 'string') {
+      rootDir = isUrl(isAbsolute)
+        ? parseUrl(isAbsolute).fullUrl
+        : isAbsolute
+    }
+
+    if (isAbsolute === true) {
+      rootDir = isUrl(fromPath)
+        ? parseUrl(fromPath).baseUrl
+        : this.context
+    }
+
+    return resolvePath(fromPath, toPath, rootDir)
   }
 
   graphql (docOrQuery, variables = {}) {

--- a/gridsome/lib/app/App.js
+++ b/gridsome/lib/app/App.js
@@ -12,7 +12,7 @@ const { defaultsDeep } = require('lodash')
 const createRoutes = require('./createRoutes')
 const { execute, graphql } = require('../graphql/graphql')
 const { version } = require('../../package.json')
-
+const { resolvePath } = require('../utils')
 
 class App {
   constructor (context, options) {
@@ -89,6 +89,8 @@ class App {
     })
 
     this.isInitialized = true
+
+    return this
   }
 
   async loadSources () {
@@ -153,6 +155,19 @@ class App {
 
   resolve (p) {
     return path.resolve(this.context, p)
+  }
+
+  resolveFilePath (fromPath, toPath, from = '') {
+    return resolvePath(fromPath, toPath, from, {
+      context: this.context
+    })
+  }
+
+  resolveNodeFilePath (node, toPath) {
+    const { getContentType } = this._app.store
+    const { collection: { fileBasePath } } = getContentType(node.typeName)
+
+    return app.resolveFilePath(node.internal.origin, toPath, fileBasePath)
   }
 
   graphql (docOrQuery, variables = {}) {

--- a/gridsome/lib/app/BaseStore.js
+++ b/gridsome/lib/app/BaseStore.js
@@ -1,11 +1,15 @@
 const Loki = require('lokijs')
+const autoBind = require('auto-bind')
 const ContentTypeCollection = require('./ContentTypeCollection')
 
 class BaseStore {
-  constructor () {
+  constructor (app) {
+    this.app = app
     this.data = new Loki()
     this.collections = {}
     this.taxonomies = {}
+
+    autoBind(this)
 
     this.pages = this.data.addCollection('Page', {
       indices: ['type'],
@@ -48,6 +52,15 @@ class BaseStore {
 
   removePage (_id) {
     return this.pages.findAndRemove({ _id })
+  }
+
+  //
+  // helpers
+  //
+
+  resolveNodeFilePath (node, toPath) {
+    const { collection: { fileBasePath } } = this.getContentType(node.typeName)
+    return this.app.resolveFilePath(node.internal.origin, toPath, fileBasePath)
   }
 }
 

--- a/gridsome/lib/app/BaseStore.js
+++ b/gridsome/lib/app/BaseStore.js
@@ -53,15 +53,6 @@ class BaseStore {
   removePage (_id) {
     return this.pages.findAndRemove({ _id })
   }
-
-  //
-  // helpers
-  //
-
-  resolveNodeFilePath (node, toPath) {
-    const { collection: { fileBasePath } } = this.getContentType(node.typeName)
-    return this.app.resolveFilePath(node.internal.origin, toPath, fileBasePath)
-  }
 }
 
 module.exports = BaseStore

--- a/gridsome/lib/app/ContentTypeCollection.js
+++ b/gridsome/lib/app/ContentTypeCollection.js
@@ -4,7 +4,7 @@ const EventEmitter = require('events')
 const camelCase = require('camelcase')
 const dateFormat = require('dateformat')
 const slugify = require('@sindresorhus/slugify')
-const { mapKeys, cloneDeep, deepMerge } = require('lodash')
+const { mapKeys, cloneDeep } = require('lodash')
 const { warn } = require('../utils/log')
 
 class ContentTypeCollection extends EventEmitter {
@@ -16,8 +16,8 @@ class ContentTypeCollection extends EventEmitter {
 
     this.options = { refs: {}, fields: {}, ...options }
     this.typeName = options.typeName
-    this.fileBasePath = options.fileBasePath || pluginStore._fileBasePath
     this.description = options.description
+    this.resolveAbsolutePaths = options.resolveAbsolutePaths || false
     this.collection = store.data.addCollection(options.typeName, {
       unique: ['_id', 'path'],
       indices: ['date'],
@@ -174,7 +174,7 @@ class ContentTypeCollection extends EventEmitter {
   }
 
   resolveFilePath (...args) {
-    return this._pluginStore._app.resolveFilePath(...args, this.fileBasePath)
+    return this._pluginStore._app.resolveFilePath(...args, this.resolveAbsolutePaths)
   }
 
   makePath ({ date, slug }) {

--- a/gridsome/lib/app/ContentTypeCollection.js
+++ b/gridsome/lib/app/ContentTypeCollection.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const crypto = require('crypto')
 const EventEmitter = require('events')
 const camelCase = require('camelcase')
@@ -15,6 +16,7 @@ class ContentTypeCollection extends EventEmitter {
 
     this.options = { refs: {}, fields: {}, ...options }
     this.typeName = options.typeName
+    this.fileBasePath = options.fileBasePath || pluginStore._fileBasePath
     this.description = options.description
     this.collection = store.data.addCollection(options.typeName, {
       unique: ['_id', 'path'],
@@ -66,15 +68,17 @@ class ContentTypeCollection extends EventEmitter {
       this.transformNodeOptions(options, internal)
     }
 
-    node.fields = mapKeys(options.fields || {}, (v, key) => {
+    const fields = mapKeys(options.fields || {}, (v, key) => {
       return key.startsWith('__') ? key : camelCase(key)
     })
 
-    node.title = options.title || node.fields.title || node.title
-    node.date = options.date || node.fields.date || node.date
-    node.slug = options.slug || node.fields.slug || this.slugify(node.title)
+    node.title = options.title || fields.title || node.title
+    node.date = options.date || fields.date || node.date
+    node.slug = options.slug || fields.slug || this.slugify(node.title)
     node.internal = Object.assign({}, node.internal, internal)
     node.path = options.path || this.makePath(node)
+
+    node.fields = this.processNodeFields(fields, node.internal.origin)
 
     this.emit('change', node, oldNode)
 
@@ -99,17 +103,19 @@ class ContentTypeCollection extends EventEmitter {
       this.transformNodeOptions(options, internal)
     }
 
-    node.fields = mapKeys(options.fields, (v, key) => {
+    const fields = mapKeys(options.fields, (v, key) => {
       return key.startsWith('__') ? key : camelCase(key)
     })
 
-    node.title = options.title || node.fields.title || options._id
-    node.date = options.date || node.fields.date || new Date().toISOString()
-    node.slug = options.slug || node.fields.slug || this.slugify(node.title)
-    node.content = options.content || node.fields.content || ''
-    node.excerpt = options.excerpt || node.fields.excerpt || ''
+    node.title = options.title || fields.title || options._id
+    node.date = options.date || fields.date || new Date().toISOString()
+    node.slug = options.slug || fields.slug || this.slugify(node.title)
+    node.content = options.content || fields.content || ''
+    node.excerpt = options.excerpt || fields.excerpt || ''
     node.path = options.path || this.makePath(node)
     node.withPath = !!options.path
+
+    node.fields = this.processNodeFields(fields, node.internal.origin)
 
     return node
   }
@@ -136,6 +142,39 @@ class ContentTypeCollection extends EventEmitter {
     if (result.fields) {
       options.fields = Object.assign(options.fields || {}, result.fields)
     }
+  }
+
+  processNodeFields (fields, origin) {
+    const processField = field => {
+      switch (typeof field) {
+        case 'object':
+          return processFields(field)
+        case 'string':
+          if (path.extname(field).length > 1) {
+            return this.resolveFilePath(origin, field)
+          }
+        default:
+          return field
+      }
+    }
+
+    const processFields = fields => {
+      const res = {}
+
+      for (const key in fields) {
+        res[key] = Array.isArray(fields[key])
+          ? fields[key].map(processField)
+          : processField(fields[key])
+      }
+
+      return res
+    }
+
+    return processFields(fields)
+  }
+
+  resolveFilePath (...args) {
+    return this._pluginStore._app.resolveFilePath(...args, this.fileBasePath)
   }
 
   makePath ({ date, slug }) {

--- a/gridsome/lib/app/PluginAPI.js
+++ b/gridsome/lib/app/PluginAPI.js
@@ -9,22 +9,9 @@ class PluginAPI {
     this._app = app
 
     this.context = app.context
+    this.store = new PluginStore(app, entry.options, { transformers })
 
     autoBind(this)
-
-    const pluginTransformers = transformers || mapValues(app.config.transformers, transformer => {
-      return new transformer.TransformerClass(transformer.options, {
-        localOptions: entry.options[transformer.name] || {},
-        context: app.context,
-        queue: app.queue,
-        cache,
-        nodeCache
-      })
-    })
-
-    this.store = new PluginStore(app, entry.options.typeName, {
-      transformers: pluginTransformers
-    })
 
     if (process.env.NODE_ENV === 'development') {
       let regenerateTimeout = null

--- a/gridsome/lib/utils/index.js
+++ b/gridsome/lib/utils/index.js
@@ -26,7 +26,7 @@ exports.resolvePath = function (fromPath, toPath, rootDir) {
   if (typeof toPath !== 'string') return toPath
   if (typeof fromPath !== 'string') return toPath
   if (path.extname(toPath).length <= 1) return toPath
-  if (/^(https?:)?\/{2}\w+/.test(toPath)) return toPath
+  if (isUrl(toPath)) return toPath
   if (mime.lookup(toPath) === 'application/x-msdownload') return toPath
   if (!mime.lookup(toPath)) return toPath
 
@@ -46,7 +46,10 @@ exports.resolvePath = function (fromPath, toPath, rootDir) {
       }
     }
 
-    return { rootPath, basePath }
+    return {
+      rootPath,
+      basePath
+    }
   }
 
   if (isRelative(toPath)) {

--- a/gridsome/lib/utils/index.js
+++ b/gridsome/lib/utils/index.js
@@ -8,8 +8,9 @@ exports.forwardSlash = function (input) {
   return slash(input)
 }
 
-exports.resolvePath = function (fromPath, toPath, from = '', { context }) {
+exports.resolvePath = function (fromPath, toPath, isAbsolute, { context }) {
   if (typeof toPath !== 'string') return toPath
+  if (typeof fromPath !== 'string') return toPath
   if (path.extname(toPath).length <= 1) return toPath
   if (/^(https?:)?\/{2}\w+/.test(toPath)) return toPath
   if (mime.lookup(toPath) === 'application/x-msdownload') return toPath
@@ -29,21 +30,11 @@ exports.resolvePath = function (fromPath, toPath, from = '', { context }) {
     isUrl = true
   }
 
-  if (from) {
-    if (from === 'file' || from === 'path') {
-      return isUrl
-        ? joinUrl(dirName, toPath)
-        : path.join(dirName, toPath)
-    } else if (from === 'root' || from === 'host') {
-      return isUrl
-        ? joinUrl(toPath)
-        : path.join(context, toPath)
-    } else if (path.isAbsolute(from)) {
-      return isUrl
-        ? joinUrl(from, toPath)
-        : path.join(from, toPath)
-    }
-  } else if (toPath.startsWith('.') && isRelative(toPath)) {
+  if (typeof isAbsolute === 'string' && path.isAbsolute(isAbsolute)) {
+    return isUrl ? joinUrl(isAbsolute, toPath) : path.join(isAbsolute, toPath)
+  } else if (isAbsolute === true && !isRelative(toPath)) {
+    return isUrl ? joinUrl(toPath) : path.join(context, toPath)
+  } else if (isRelative(toPath)) {
     return isUrl
       ? joinUrl(path.resolve(dirName, toPath))
       : path.resolve(dirName, toPath)

--- a/gridsome/lib/utils/index.js
+++ b/gridsome/lib/utils/index.js
@@ -1,5 +1,53 @@
+const url = require('url')
+const path = require('path')
 const slash = require('slash')
+const mime = require('mime-types')
+const isRelative = require('is-relative')
 
 exports.forwardSlash = function (input) {
   return slash(input)
+}
+
+exports.resolvePath = function (fromPath, toPath, from = '', { context }) {
+  if (typeof toPath !== 'string') return toPath
+  if (path.extname(toPath).length <= 1) return toPath
+  if (/^(https?:)?\/{2}\w+/.test(toPath)) return toPath
+  if (mime.lookup(toPath) === 'application/x-msdownload') return toPath
+  if (!mime.lookup(toPath)) return toPath
+
+  let isUrl = false
+  let dirName = path.dirname(fromPath)
+
+  const joinUrl = (...parts) => {
+    return context + exports.forwardSlash(path.join('/', ...parts))
+  }
+
+  if (/^(https?:)?\/{2}\w+/.test(fromPath)) {
+    const info = url.parse(fromPath.replace(/[^/]*\/?$/, ''))
+    context = `${info.protocol}//${info.host}`
+    dirName = info.path.replace(/\/+$/, '')
+    isUrl = true
+  }
+
+  if (from) {
+    if (from === 'file' || from === 'path') {
+      return isUrl
+        ? joinUrl(dirName, toPath)
+        : path.join(dirName, toPath)
+    } else if (from === 'root' || from === 'host') {
+      return isUrl
+        ? joinUrl(toPath)
+        : path.join(context, toPath)
+    } else if (path.isAbsolute(from)) {
+      return isUrl
+        ? joinUrl(from, toPath)
+        : path.join(from, toPath)
+    }
+  } else if (toPath.startsWith('.') && isRelative(toPath)) {
+    return isUrl
+      ? joinUrl(path.resolve(dirName, toPath))
+      : path.resolve(dirName, toPath)
+  }
+
+  return toPath
 }

--- a/gridsome/package.json
+++ b/gridsome/package.json
@@ -66,6 +66,7 @@
     "imagemin-jpegoptim": "^5.2.0",
     "imagemin-pngquant": "^6.0.0",
     "imagemin-webp": "^4.1.0",
+    "is-relative": "^1.0.0",
     "jest-worker": "^23.2.0",
     "json-loader": "^0.5.7",
     "loader-utils": "^1.1.0",

--- a/gridsome/package.json
+++ b/gridsome/package.json
@@ -67,6 +67,7 @@
     "imagemin-pngquant": "^6.0.0",
     "imagemin-webp": "^4.1.0",
     "is-relative": "^1.0.0",
+    "is-url": "^1.2.4",
     "jest-worker": "^23.2.0",
     "json-loader": "^0.5.7",
     "loader-utils": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
       "gridsome/lib/**/*.js"
     ],
     "testPathIgnorePatterns": [
+      "/__fixtures__/",
       "/projects/",
       "/scripts/"
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -7319,6 +7319,13 @@ is-relative@^0.1.0:
   resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-0.1.3.tgz#905fee8ae86f45b3ec614bc3c15c869df0876e82"
   integrity sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=
 
+is-relative@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-1.0.0.tgz#a1bb6935ce8c5dba1e8b9754b9b2dcc020e2260d"
+  integrity sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==
+  dependencies:
+    is-unc-path "^1.0.0"
+
 is-resolvable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
@@ -7367,6 +7374,13 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-unc-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-unc-path/-/is-unc-path-1.0.0.tgz#d731e8898ed090a12c352ad2eaed5095ad322c9d"
+  integrity sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==
+  dependencies:
+    unc-path-regex "^0.1.2"
 
 is-url@^1.2.0, is-url@^1.2.4:
   version "1.2.4"
@@ -12815,6 +12829,11 @@ unbzip2-stream@^1.0.9:
   dependencies:
     buffer "^3.0.1"
     through "^2.3.6"
+
+unc-path-regex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
+  integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
 unherit@^1.0.4:
   version "1.1.1"


### PR DESCRIPTION
This PR resolves all relative file paths in node fields. It also makes it possible to resolve absolute paths with a `resolveAbsolutePaths` option. That will make Gridsome able to process image paths from Netlify CMS etc.

When a field contains `/images/image.png`, Gridsome normally assumes the image is located in `/static/images/*` and leave the field as is, since they will be copied during deployment. But Gridsome will convert the field into an absolute file path resolved from the root folder if `resolveAbsolutePaths` is `true`. Your images should be located at `{root}/images/*`. The option can also take an absolute path to a folder containing the referenced files.

It also works for urls. Absolute pathnames like `/image.jpg` converts into absolute urls when `resolveAbsolutePaths` is `true`.
