### PR TITLE
Cleanup GraphQL schema

### DIFF
--- a/gridsome/__tests__/PluginStore.spec.js
+++ b/gridsome/__tests__/PluginStore.spec.js
@@ -39,13 +39,13 @@ test('add node', () => {
 
   const emit = jest.spyOn(contentType, 'emit')
   const node = contentType.addNode({
-    _id: 'test',
+    id: 'test',
     title: 'Lorem ipsum dolor sit amet',
     date: '2018-09-04T23:20:33.918Z'
   })
 
   expect(node).toHaveProperty('$loki')
-  expect(node._id).toEqual('test')
+  expect(node.id).toEqual('test')
   expect(node.typeName).toEqual('TestPost')
   expect(node.title).toEqual('Lorem ipsum dolor sit amet')
   expect(node.slug).toEqual('lorem-ipsum-dolor-sit-amet')
@@ -66,7 +66,7 @@ test('update node', () => {
   const emit = jest.spyOn(contentType, 'emit')
 
   const oldNode = contentType.addNode({
-    _id: 'test',
+    id: 'test',
     date: '2018-09-04T23:20:33.918Z'
   })
 
@@ -76,7 +76,7 @@ test('update node', () => {
     title: 'New title'
   })
 
-  expect(node._id).toEqual('test')
+  expect(node.id).toEqual('test')
   expect(node.typeName).toEqual('TestPost')
   expect(node.title).toEqual('New title')
   expect(node.slug).toEqual('new-title')
@@ -96,7 +96,7 @@ test('remove node', () => {
 
   const emit = jest.spyOn(contentType, 'emit')
 
-  contentType.addNode({ _id: 'test' })
+  contentType.addNode({ id: 'test' })
   contentType.removeNode('test')
 
   expect(contentType.getNode('test')).toBeNull()
@@ -112,14 +112,14 @@ test('add type with ref', () => {
     typeName: 'TestPost',
     refs: {
       author: {
-        key: '_id',
+        key: 'id',
         typeName: 'TestAuthor'
       }
     }
   })
 
   expect(contentType.options.refs.author).toMatchObject({
-    key: '_id',
+    key: 'id',
     fieldName: 'author',
     typeName: 'TestAuthor',
     description: 'Reference to TestAuthor'
@@ -396,7 +396,7 @@ test('add page with query', () => {
 
   const page = api.store.addPage('page', {
     pageQuery: {
-      content: 'query Test { page { _id } }',
+      content: 'query Test { page { id } }',
       options: {
         foo: 'bar'
       }
@@ -404,7 +404,7 @@ test('add page with query', () => {
   })
 
   expect(typeof page.pageQuery.query).toEqual('object')
-  expect(page.pageQuery.content).toEqual('query Test { page { _id } }')
+  expect(page.pageQuery.content).toEqual('query Test { page { id } }')
   expect(page.pageQuery.options).toMatchObject({ foo: 'bar' })
   expect(page.pageQuery.paginate).toMatchObject({
     collection: undefined,
@@ -416,7 +416,7 @@ test('update page', () => {
   const api = createPlugin()
 
   api.store.addPage('page', {
-    _id: 'test',
+    id: 'test',
     title: 'Lorem ipsum dolor sit amet',
     internal: { origin: 'Test.vue' }
   })
@@ -439,7 +439,7 @@ test('update page', () => {
 test('update page path when slug is changed', () => {
   const api = createPlugin()
 
-  api.store.addPage('page', { _id: 'test' })
+  api.store.addPage('page', { id: 'test' })
 
   const page = api.store.updatePage('test', {
     slug: 'new-title'
@@ -455,7 +455,7 @@ test('remove page', () => {
 
   const emit = jest.spyOn(api.store, 'emit')
 
-  api.store.addPage('page', { _id: 'test' })
+  api.store.addPage('page', { id: 'test' })
   api.store.removePage('test')
 
   expect(api.store.getPage('test')).toBeNull()

--- a/gridsome/lib/app/ContentTypeCollection.js
+++ b/gridsome/lib/app/ContentTypeCollection.js
@@ -19,7 +19,7 @@ class ContentTypeCollection extends EventEmitter {
     this.description = options.description
     this.resolveAbsolutePaths = options.resolveAbsolutePaths || false
     this.collection = store.data.addCollection(options.typeName, {
-      unique: ['_id', 'path'],
+      unique: ['id', 'path'],
       indices: ['date'],
       autoupdate: true
     })
@@ -54,8 +54,8 @@ class ContentTypeCollection extends EventEmitter {
     return node
   }
 
-  getNode (_id) {
-    return this.collection.findOne({ _id })
+  getNode (id) {
+    return this.collection.findOne({ id })
   }
 
   updateNode (id, options) {
@@ -85,18 +85,21 @@ class ContentTypeCollection extends EventEmitter {
     return node
   }
 
-  removeNode (_id) {
-    const oldNode = this.collection.findOne({ _id })
+  removeNode (id) {
+    const oldNode = this.collection.findOne({ id })
 
-    this.collection.findAndRemove({ _id })
+    this.collection.findAndRemove({ id })
     this.emit('change', undefined, oldNode)
   }
 
   createNode (options = {}) {
     const { typeName } = this.options
     const internal = this.createInternals(options.internal)
-    const _id = options._id || this.makeUid(JSON.stringify(options))
-    let node = { _id, typeName, internal }
+    const id = options.id || options._id || this.makeUid(JSON.stringify(options))
+    let node = { id, typeName, internal }
+
+    // TODO: remove before 1.0
+    node._id = id
 
     // transform content with transformer for given mime type
     if (internal.content && internal.mimeType) {
@@ -107,7 +110,7 @@ class ContentTypeCollection extends EventEmitter {
       return key.startsWith('__') ? key : camelCase(key)
     })
 
-    node.title = options.title || fields.title || options._id
+    node.title = options.title || fields.title || node.id
     node.date = options.date || fields.date || new Date().toISOString()
     node.slug = options.slug || fields.slug || this.slugify(node.title)
     node.content = options.content || fields.content || ''

--- a/gridsome/lib/app/PluginStore.js
+++ b/gridsome/lib/app/PluginStore.js
@@ -58,7 +58,7 @@ class Source extends EventEmitter {
     // normalize references
     const refs = mapValues(options.refs, (ref, key) => ({
       fieldName: key,
-      key: ref.key || '_id',
+      key: ref.key || 'id',
       typeName: ref.typeName || options.typeName,
       description: Array.isArray(ref.typeName)
         ? `Reference to ${ref.typeName.join(', ')}`
@@ -91,11 +91,14 @@ class Source extends EventEmitter {
 
   addPage (type, options) {
     const page = {
-      _id: options._id,
+      id: options.id || options._id,
       type: type || 'page',
       component: options.component,
       internal: this.createInternals(options.internal)
     }
+
+    // TODO: remove before 1.0
+    page._id = page.id
 
     try {
       page.pageQuery = parsePageQuery(options.pageQuery || {})

--- a/gridsome/lib/graphql/schema/infer-types.js
+++ b/gridsome/lib/graphql/schema/infer-types.js
@@ -38,8 +38,8 @@ function inferType (value, key, nodeType) {
     const type = inferType(value[0], key, nodeType)
     return type !== null ? {
       type: new GraphQLList(type.type),
-      resolve: (fields, args, context, { fieldName }) => {
-        const value = fields[fieldName]
+      resolve: (obj, args, context, info) => {
+        const value = fieldResolver(obj, args, context, info)
         return Array.isArray(value) ? value : []
       }
     } : null

--- a/gridsome/lib/graphql/schema/infer-types.js
+++ b/gridsome/lib/graphql/schema/infer-types.js
@@ -1,5 +1,6 @@
 const camelCase = require('camelcase')
 const { mapValues, isEmpty } = require('lodash')
+const { fieldResolver } = require('./resolvers')
 const { isDate, dateType } = require('./types/date')
 
 const {
@@ -10,12 +11,6 @@ const {
   GraphQLBoolean,
   GraphQLObjectType
 } = require('../graphql')
-
-const resolve = (obj, args, ctx, { fieldName }) => {
-  return obj.hasOwnProperty('$loki') // the node object
-    ? obj.fields[fieldName]
-    : obj[fieldName]
-}
 
 function inferTypes (nodes, nodeType) {
   const fields = {}
@@ -58,11 +53,20 @@ function inferType (value, key, nodeType) {
 
   switch (type) {
     case 'string':
-      return { type: GraphQLString, resolve }
+      return {
+        type: GraphQLString,
+        resolve: fieldResolver
+      }
     case 'boolean':
-      return { type: GraphQLBoolean, resolve }
+      return {
+        type: GraphQLBoolean,
+        resolve: fieldResolver
+      }
     case 'number':
-      return { type: is32BitInt(value) ? GraphQLInt : GraphQLFloat, resolve }
+      return {
+        type: is32BitInt(value) ? GraphQLInt : GraphQLFloat,
+        resolve: fieldResolver
+      }
     case 'object':
       return createObjectType(value, key, nodeType)
   }

--- a/gridsome/lib/graphql/schema/infer-types.js
+++ b/gridsome/lib/graphql/schema/infer-types.js
@@ -11,6 +11,12 @@ const {
   GraphQLObjectType
 } = require('../graphql')
 
+const resolve = (obj, args, ctx, { fieldName }) => {
+  return obj.hasOwnProperty('$loki') // the node object
+    ? obj.fields[fieldName]
+    : obj[fieldName]
+}
+
 function inferTypes (nodes, nodeType) {
   const fields = {}
   let node, type
@@ -52,11 +58,11 @@ function inferType (value, key, nodeType) {
 
   switch (type) {
     case 'string':
-      return { type: GraphQLString }
+      return { type: GraphQLString, resolve }
     case 'boolean':
-      return { type: GraphQLBoolean }
+      return { type: GraphQLBoolean, resolve }
     case 'number':
-      return { type: is32BitInt(value) ? GraphQLInt : GraphQLFloat }
+      return { type: is32BitInt(value) ? GraphQLInt : GraphQLFloat, resolve }
     case 'object':
       return createObjectType(value, key, nodeType)
   }

--- a/gridsome/lib/graphql/schema/interfaces.js
+++ b/gridsome/lib/graphql/schema/interfaces.js
@@ -8,20 +8,9 @@ const {
 
 const { GraphQLDate } = require('./types/date')
 
-const internalInterface = new GraphQLInterfaceType({
-  name: 'InternalInterface',
-  fields: () => ({
-    origin: { type: GraphQLString },
-    mimeType: { type: GraphQLString },
-    content: { type: GraphQLString },
-    timestamp: { type: GraphQLInt }
-  })
-})
-
 const nodeInterface = new GraphQLInterfaceType({
   name: 'NodeInterface',
   fields: () => ({
-    internal: { type: new GraphQLNonNull(internalInterface) },
     id: { type: new GraphQLNonNull(GraphQLID) },
     title: { type: GraphQLString },
     slug: { type: GraphQLString },
@@ -33,6 +22,5 @@ const nodeInterface = new GraphQLInterfaceType({
 })
 
 module.exports = {
-  nodeInterface,
-  internalInterface
+  nodeInterface
 }

--- a/gridsome/lib/graphql/schema/interfaces.js
+++ b/gridsome/lib/graphql/schema/interfaces.js
@@ -21,8 +21,8 @@ const internalInterface = new GraphQLInterfaceType({
 const nodeInterface = new GraphQLInterfaceType({
   name: 'NodeInterface',
   fields: () => ({
-    _id: { type: new GraphQLNonNull(GraphQLID) },
     internal: { type: new GraphQLNonNull(internalInterface) },
+    id: { type: new GraphQLNonNull(GraphQLID) },
     title: { type: GraphQLString },
     slug: { type: GraphQLString },
     path: { type: GraphQLString },

--- a/gridsome/lib/graphql/schema/nodes/createQuery.js
+++ b/gridsome/lib/graphql/schema/nodes/createQuery.js
@@ -8,7 +8,8 @@ module.exports = nodeType => {
   return {
     type: nodeType,
     args: {
-      _id: { type: GraphQLString },
+      _id: { type: GraphQLString, deprecationReason: 'Use id instead.' },
+      id: { type: GraphQLString },
       path: { type: GraphQLString },
       nullable: {
         type: GraphQLBoolean,
@@ -16,14 +17,14 @@ module.exports = nodeType => {
         description: 'Will return an error if not nullable.'
       }
     },
-    resolve (object, { _id, path, nullable }, { store }, { returnType }) {
+    resolve (object, { _id, id = _id, path, nullable }, { store }, { returnType }) {
       const { collection } = store.getContentType(returnType)
-      const node = _id ? collection.get(_id) : collection.findOne({ path })
+      const node = id ? collection.get(id) : collection.findOne({ path })
 
       if (!node && !nullable) {
         const message = path
           ? `${path} was not found`
-          : `A ${returnType} with id ${_id} was not found`
+          : `A ${returnType} with id ${id} was not found`
 
         throw new GraphQLError(message)
       }

--- a/gridsome/lib/graphql/schema/nodes/createType.js
+++ b/gridsome/lib/graphql/schema/nodes/createType.js
@@ -42,7 +42,6 @@ module.exports = ({ contentType, nodeTypes, fields }) => {
 
         ...extendNodeType(contentType, nodeType, nodeTypes),
         ...createFields(contentType, fields),
-        ...createBelongsToRefs(contentType, nodeTypes),
 
         _id: {
           deprecationReason: 'Use node.id instead.',
@@ -152,39 +151,4 @@ function createRefs (contentType, nodeTypes, fields) {
       }
     }
   })
-}
-
-function createBelongsToRefs (contentType, nodeTypes) {
-  if (isEmpty(contentType.belongsTo)) return null
-
-  const belongsTo = {
-    resolve: obj => obj,
-    type: new GraphQLObjectType({
-      name: `${contentType.typeName}BelongsTo`,
-      fields: () => mapValues(contentType.belongsTo, ref => {
-        const { foreignSchemaType, description } = ref
-        const nodeType = nodeTypes[foreignSchemaType]
-
-        return {
-          description,
-          type: new GraphQLList(nodeType),
-          resolve: (obj, args, { store }) => {
-            const { collection } = store.getContentType(foreignSchemaType)
-            const value = obj[ref.localKey]
-            const key = ref.foreignKey
-
-            return collection.find().filter(node => {
-              const field = node.fields[key]
-
-              return Array.isArray(field)
-                ? field.includes(value)
-                : false
-            })
-          }
-        }
-      })
-    })
-  }
-
-  return { belongsTo }
 }

--- a/gridsome/lib/graphql/schema/nodes/createType.js
+++ b/gridsome/lib/graphql/schema/nodes/createType.js
@@ -27,11 +27,7 @@ module.exports = ({ contentType, nodeTypes, fields }) => {
       const refs = createRefs(contentType, nodeTypes, customFields)
 
       const nodeFields = {
-        id: {
-          type: new GraphQLNonNull(GraphQLID),
-          resolve: node => node._id
-        },
-
+        id: { type: new GraphQLNonNull(GraphQLID) },
         title: { type: GraphQLString },
         slug: { type: GraphQLString },
         path: { type: GraphQLString },
@@ -46,7 +42,8 @@ module.exports = ({ contentType, nodeTypes, fields }) => {
 
         _id: {
           deprecationReason: 'Use node.id instead.',
-          type: new GraphQLNonNull(GraphQLID)
+          type: new GraphQLNonNull(GraphQLID),
+          resolve: node => node.id
         },
       }
 

--- a/gridsome/lib/graphql/schema/nodes/createType.js
+++ b/gridsome/lib/graphql/schema/nodes/createType.js
@@ -29,8 +29,12 @@ module.exports = ({ contentType, nodeTypes, fields }) => {
     interfaces: [nodeInterface],
     isTypeOf: node => node.typeName === contentType.typeName,
     fields: () => ({
-      _id: { type: new GraphQLNonNull(GraphQLID) },
       internal: { type: new GraphQLNonNull(internalType) },
+      id: {
+        type: new GraphQLNonNull(GraphQLID),
+        resolve: node => node._id
+      },
+
       title: { type: GraphQLString },
       slug: { type: GraphQLString },
       path: { type: GraphQLString },
@@ -42,6 +46,10 @@ module.exports = ({ contentType, nodeTypes, fields }) => {
       ...createFields(contentType, fields),
       ...createRefs(contentType, nodeTypes, fields),
       ...createBelongsToRefs(contentType, nodeTypes)
+      _id: {
+        deprecationReason: 'Use node.id instead.',
+        type: new GraphQLNonNull(GraphQLID)
+      },
     })
   })
 

--- a/gridsome/lib/graphql/schema/nodes/createType.js
+++ b/gridsome/lib/graphql/schema/nodes/createType.js
@@ -23,8 +23,8 @@ module.exports = ({ contentType, nodeTypes, fields }) => {
     interfaces: [nodeInterface],
     isTypeOf: node => node.typeName === contentType.typeName,
     fields: () => {
-      const customFields = omit(fields, SPECIAL_FIELDS)
-      const refs = createRefs(contentType, nodeTypes, customFields)
+      const rootFields = omit(fields, SPECIAL_FIELDS)
+      const refs = createRefs(contentType, nodeTypes, rootFields)
 
       const nodeFields = {
         id: { type: new GraphQLNonNull(GraphQLID) },
@@ -35,10 +35,10 @@ module.exports = ({ contentType, nodeTypes, fields }) => {
         excerpt: { type: GraphQLString },
         date: dateType,
 
-        ...customFields,
+        ...rootFields,
         ...refs,
         ...extendNodeType(contentType, nodeType, nodeTypes),
-        ...createFields(contentType, customFields),
+        ...createFields(contentType, fields),
 
         _id: {
           deprecationReason: 'Use node.id instead.',

--- a/gridsome/lib/graphql/schema/nodes/createType.js
+++ b/gridsome/lib/graphql/schema/nodes/createType.js
@@ -29,7 +29,6 @@ module.exports = ({ contentType, nodeTypes, fields }) => {
     interfaces: [nodeInterface],
     isTypeOf: node => node.typeName === contentType.typeName,
     fields: () => ({
-      internal: { type: new GraphQLNonNull(internalType) },
       id: {
         type: new GraphQLNonNull(GraphQLID),
         resolve: node => node._id

--- a/gridsome/lib/graphql/schema/nodes/createType.js
+++ b/gridsome/lib/graphql/schema/nodes/createType.js
@@ -15,41 +15,54 @@ const {
   GraphQLInterfaceType
 } = require('../../graphql')
 
-const fieldsInterface = new GraphQLInterfaceType({
-  name: 'FieldsInterface',
-  fields: () => ({
-    title: { type: GraphQLString }
-  })
-})
-
 module.exports = ({ contentType, nodeTypes, fields }) => {
   const nodeType = new GraphQLObjectType({
     name: contentType.typeName,
     description: contentType.description,
     interfaces: [nodeInterface],
     isTypeOf: node => node.typeName === contentType.typeName,
-    fields: () => ({
-      id: {
-        type: new GraphQLNonNull(GraphQLID),
-        resolve: node => node._id
-      },
+    fields: () => {
+      const refs = createRefs(contentType, nodeTypes, fields)
 
-      title: { type: GraphQLString },
-      slug: { type: GraphQLString },
-      path: { type: GraphQLString },
-      content: { type: GraphQLString },
-      excerpt: { type: GraphQLString },
-      date: dateType,
+      const nodeFields = {
+        ...fields,
+        ...refs,
+        
+        id: {
+          type: new GraphQLNonNull(GraphQLID),
+          resolve: node => node._id
+        },
 
-      ...extendNodeType(contentType, nodeType, nodeTypes),
-      ...createFields(contentType, fields),
-      ...createRefs(contentType, nodeTypes, fields),
-      ...createBelongsToRefs(contentType, nodeTypes)
-      _id: {
-        deprecationReason: 'Use node.id instead.',
-        type: new GraphQLNonNull(GraphQLID)
-      },
-    })
+        title: { type: GraphQLString },
+        slug: { type: GraphQLString },
+        path: { type: GraphQLString },
+        content: { type: GraphQLString },
+        excerpt: { type: GraphQLString },
+        date: dateType,
+
+        ...extendNodeType(contentType, nodeType, nodeTypes),
+        ...createFields(contentType, fields),
+        ...createBelongsToRefs(contentType, nodeTypes),
+
+        _id: {
+          deprecationReason: 'Use node.id instead.',
+          type: new GraphQLNonNull(GraphQLID)
+        },
+      }
+
+      if (!isEmpty(refs)) {
+        nodeFields.refs = {
+          resolve: obj => obj,
+          deprecationReason: 'Use ref on node instead.',
+          type: new GraphQLObjectType({
+            name: `${contentType.typeName}References`,
+            fields: () => refs
+          })
+        }
+      }
+
+      return nodeFields
+    }
   })
 
   return nodeType
@@ -84,14 +97,13 @@ function extendNodeType (contentType, nodeType, nodeTypes) {
 }
 
 function createFields (contentType, customFields) {
+  if (isEmpty(customFields)) return {}
+
   const fields = {
+    deprecationReason: 'Get field on node instead.',
     type: new GraphQLObjectType({
       name: `${contentType.typeName}Fields`,
-      interfaces: [fieldsInterface],
-      fields: {
-        title: { type: GraphQLString },
-        ...customFields
-      }
+      fields: () => customFields
     })
   }
 
@@ -101,53 +113,45 @@ function createFields (contentType, customFields) {
 function createRefs (contentType, nodeTypes, fields) {
   if (isEmpty(contentType.options.refs)) return null
 
-  const refs = {
-    resolve: obj => obj,
-    type: new GraphQLObjectType({
-      name: `${contentType.typeName}References`,
-      fields: () => mapValues(contentType.options.refs, (ref, key) => {
-        const { typeName, description } = ref
-        const field = fields[key] || { type: GraphQLString }
+  return mapValues(contentType.options.refs, (ref, key) => {
+    const { typeName, description } = ref
+    const field = fields[key] || { type: GraphQLString }
 
-        const isList = field.type instanceof GraphQLList
-        let refType = nodeTypes[typeName]
+    const isList = field.type instanceof GraphQLList
+    let refType = nodeTypes[typeName]
+
+    if (Array.isArray(typeName)) {
+      // TODO: create union collection
+      const fieldTypeName = camelCase(key, { pascalCase: true })
+      refType = new GraphQLUnionType({
+        name: `${contentType.typeName}${fieldTypeName}Union`,
+        interfaces: [nodeInterface],
+        types: typeName.map(typeName => nodeTypes[typeName])
+      })
+    }
+
+    return {
+      description,
+      type: isList ? new GraphQLList(refType) : refType,
+      resolve: (obj, args, { store }) => {
+        const value = obj.fields[key] || []
+        const query = Array.isArray(value)
+          ? { [ref.key]: { $in: value }}
+          : { [ref.key]: value }
 
         if (Array.isArray(typeName)) {
-          // TODO: create union collection
-          const fieldTypeName = camelCase(key, { pascalCase: true })
-          refType = new GraphQLUnionType({
-            name: `${contentType.typeName}${fieldTypeName}Union`,
-            interfaces: [nodeInterface],
-            types: typeName.map(typeName => nodeTypes[typeName])
-          })
+          // TODO: search multiple collections
+          return []
         }
 
-        return {
-          description,
-          type: isList ? new GraphQLList(refType) : refType,
-          resolve: (obj, args, { store }) => {
-            const value = obj.fields[key] || []
-            const query = Array.isArray(value)
-              ? { [ref.key]: { $in: value }}
-              : { [ref.key]: value }
+        const { collection } = store.getContentType(typeName)
 
-            if (Array.isArray(typeName)) {
-              // TODO: search multiple collections
-              return []
-            }
-
-            const { collection } = store.getContentType(typeName)
-
-            return isList
-              ? collection.find(query)
-              : collection.findOne(query)
-          }
-        }
-      })
-    })
-  }
-
-  return { refs }
+        return isList
+          ? collection.find(query)
+          : collection.findOne(query)
+      }
+    }
+  })
 }
 
 function createBelongsToRefs (contentType, nodeTypes) {

--- a/gridsome/lib/graphql/schema/pages/index.js
+++ b/gridsome/lib/graphql/schema/pages/index.js
@@ -23,8 +23,12 @@ module.exports = () => {
   const pageType = new GraphQLObjectType({
     name: 'Page',
     fields: () => ({
+      id: {
+        type: new GraphQLNonNull(GraphQLID),
+        resolve: node => node.$loki
+      },
+
       type: { type: new GraphQLNonNull(GraphQLString) },
-      internal: { type: new GraphQLNonNull(internalType) },
       title: { type: GraphQLString },
       slug: { type: GraphQLString },
       path: { type: GraphQLString },
@@ -34,6 +38,7 @@ module.exports = () => {
       date: dateType,
 
       _id: {
+        deprecationReason: 'Use node.id instead.',
         type: new GraphQLNonNull(GraphQLID),
         resolve: node => node.$loki
       }

--- a/gridsome/lib/graphql/schema/resolvers.js
+++ b/gridsome/lib/graphql/schema/resolvers.js
@@ -1,0 +1,9 @@
+function fieldResolver (obj, args, ctx, { fieldName }) {
+  return obj.hasOwnProperty('$loki') // the node object
+    ? obj.fields[fieldName]
+    : obj[fieldName]
+}
+
+module.exports = {
+  fieldResolver
+}

--- a/gridsome/lib/graphql/schema/types.js
+++ b/gridsome/lib/graphql/schema/types.js
@@ -7,8 +7,6 @@ const {
   GraphQLObjectType
 } = require('../graphql')
 
-const { internalInterface } = require('./interfaces')
-
 const pageInfoType = new GraphQLObjectType({
   name: 'PageInfo',
   fields: () => ({
@@ -27,19 +25,7 @@ const sortOrderType = new GraphQLEnumType({
   }
 })
 
-const internalType = new GraphQLObjectType({
-  name: 'NodeInternal',
-  interfaces: [internalInterface],
-  fields: () => ({
-    origin: { type: GraphQLString },
-    mimeType: { type: GraphQLString },
-    content: { type: GraphQLString },
-    timestamp: { type: GraphQLInt }
-  })
-})
-
 module.exports = {
   pageInfoType,
-  sortOrderType,
-  internalType
+  sortOrderType
 }

--- a/gridsome/lib/graphql/schema/types/date.js
+++ b/gridsome/lib/graphql/schema/types/date.js
@@ -1,4 +1,5 @@
 const moment = require('moment')
+const { fieldResolver } = require('../resolvers')
 const { GraphQLString, GraphQLScalarType, Kind } = require('../../graphql')
 
 const ISO_8601_FORMAT = [
@@ -53,8 +54,11 @@ exports.dateType = {
     format: { type: GraphQLString, description: 'Date format' },
     locale: { type: GraphQLString, description: 'Locale', defaultValue: 'en' }
   },
-  resolve: (fields, { format, locale }, context, { fieldName }) => {
-    return moment(fields[fieldName]).locale(locale).format(format)
+  resolve: (obj, args, context, info) => {
+    const value = fieldResolver(obj, args, context, info)
+    const { format, locale } = args
+
+    return moment(value).locale(locale).format(format)
   }
 }
 


### PR DESCRIPTION
Flattening node types in schema by moving all fields and refs properties to the node instead. `fields.*` and `refs.*` will still be available, but marked as deprecated. Also inserts `id`, deprecating `_id` and removing `internals` from schema. These node fields cannot be overridden by custom fields: `id`, `title`, `slug`, `path`, `date`, `content` and `excerpt`.