### PR TITLE
feat: make style loader options configurable

### DIFF
--- a/gridsome/lib/app/loadConfig.js
+++ b/gridsome/lib/app/loadConfig.js
@@ -22,6 +22,16 @@ module.exports = (context, options = {}, pkg = {}) => {
   const args = options.args || {}
   const config = {}
   const plugins = []
+  const css = {
+    loaderOptions: {
+      sass: {
+        indentedSyntax: true
+      },
+      stylus: {
+        preferPathResolver: 'webpack'
+      }
+    }
+  }
 
   const localConfig = fs.existsSync(configPath)
     ? require(configPath)
@@ -102,11 +112,7 @@ module.exports = (context, options = {}, pkg = {}) => {
   config.templatePath = path.resolve(config.appPath, 'index.html')
   config.htmlTemplate = fs.readFileSync(config.templatePath, 'utf-8')
 
-  config.scss = {}
-  config.sass = {}
-  config.less = {}
-  config.stylus = {}
-  config.postcss = {}
+  config.css = defaultsDeep(css, localConfig.css || {})
 
   return Object.freeze(config)
 }

--- a/gridsome/lib/webpack/createBaseConfig.js
+++ b/gridsome/lib/webpack/createBaseConfig.js
@@ -273,6 +273,7 @@ module.exports = (app, { isProd, isServer }) => {
   }
 
   function createCSSRule (config, lang, test, loader = null, options = {}) {
+    const { css = {}, postcss = {}} = projectConfig.css.loaderOptions
     const baseRule = config.module.rule(lang).test(test)
     const modulesRule = baseRule.oneOf('modules').resourceQuery(/module/)
     const normalRule = baseRule.oneOf('normal')
@@ -296,14 +297,15 @@ module.exports = (app, { isProd, isServer }) => {
           localIdentName: `[local]_[hash:base64:8]`,
           importLoaders: 1,
           sourceMap: !isProd
-        }, lang === 'css' && options))
+        }, css))
 
       rule.use('postcss-loader')
         .loader('postcss-loader')
         .options(Object.assign({
-          plugins: [require('autoprefixer')],
           sourceMap: !isProd
-        }, lang === 'postcss' ? options : options.postcss))
+        }, postcss, {
+          plugins: (postcss.plugins || []).concat(require('autoprefixer'))
+        }))
 
       if (loader) {
         rule.use(loader).loader(loader).options(options)

--- a/gridsome/lib/webpack/createBaseConfig.js
+++ b/gridsome/lib/webpack/createBaseConfig.js
@@ -126,14 +126,12 @@ module.exports = (app, { isProd, isServer }) => {
 
   // css
 
-  createCSSRule(config, 'css', /\.css$/)
-  createCSSRule(config, 'postcss', /\.p(ost)?css$/)
-  createCSSRule(config, 'scss', /\.scss$/, 'sass-loader', projectConfig.scss)
-  createCSSRule(config, 'sass', /\.sass$/, 'sass-loader', Object.assign({ indentedSyntax: true }, projectConfig.sass))
-  createCSSRule(config, 'less', /\.less$/, 'less-loader', projectConfig.less)
-  createCSSRule(config, 'stylus', /\.styl(us)?$/, 'stylus-loader', Object.assign({
-    preferPathResolver: 'webpack'
-  }, projectConfig.stylus))
+  createCSSRule(config, 'css', /\.css$/, null, projectConfig.css.loaderConfig.css)
+  createCSSRule(config, 'postcss', /\.p(ost)?css$/, null, projectConfig.css.loaderConfig.postcss)
+  createCSSRule(config, 'scss', /\.scss$/, 'sass-loader', projectConfig.css.loaderConfig.scss)
+  createCSSRule(config, 'sass', /\.sass$/, 'sass-loader', projectConfig.css.loaderConfig.sass)
+  createCSSRule(config, 'less', /\.less$/, 'less-loader', projectConfig.css.loaderConfig.less)
+  createCSSRule(config, 'stylus', /\.styl(us)?$/, 'stylus-loader', projectConfig.css.loaderConfig.stylus)
 
   // assets
 
@@ -293,19 +291,19 @@ module.exports = (app, { isProd, isServer }) => {
 
       rule.use('css-loader')
         .loader(isServer ? 'css-loader/locals' : 'css-loader')
-        .options({
+        .options(Object.assign({
           modules,
           localIdentName: `[local]_[hash:base64:8]`,
           importLoaders: 1,
           sourceMap: !isProd
-        })
+        }, lang === 'css' && options))
 
       rule.use('postcss-loader')
         .loader('postcss-loader')
         .options(Object.assign({
           plugins: [require('autoprefixer')],
           sourceMap: !isProd
-        }, options.postcss))
+        }, lang === 'postcss' ? options : options.postcss))
 
       if (loader) {
         rule.use(loader).loader(loader).options(options)

--- a/gridsome/lib/webpack/createBaseConfig.js
+++ b/gridsome/lib/webpack/createBaseConfig.js
@@ -126,12 +126,12 @@ module.exports = (app, { isProd, isServer }) => {
 
   // css
 
-  createCSSRule(config, 'css', /\.css$/, null, projectConfig.css.loaderConfig.css)
-  createCSSRule(config, 'postcss', /\.p(ost)?css$/, null, projectConfig.css.loaderConfig.postcss)
-  createCSSRule(config, 'scss', /\.scss$/, 'sass-loader', projectConfig.css.loaderConfig.scss)
-  createCSSRule(config, 'sass', /\.sass$/, 'sass-loader', projectConfig.css.loaderConfig.sass)
-  createCSSRule(config, 'less', /\.less$/, 'less-loader', projectConfig.css.loaderConfig.less)
-  createCSSRule(config, 'stylus', /\.styl(us)?$/, 'stylus-loader', projectConfig.css.loaderConfig.stylus)
+  createCSSRule(config, 'css', /\.css$/, null, projectConfig.css.loaderOptions.css)
+  createCSSRule(config, 'postcss', /\.p(ost)?css$/, null, projectConfig.css.loaderOptions.postcss)
+  createCSSRule(config, 'scss', /\.scss$/, 'sass-loader', projectConfig.css.loaderOptions.scss)
+  createCSSRule(config, 'sass', /\.sass$/, 'sass-loader', projectConfig.css.loaderOptions.sass)
+  createCSSRule(config, 'less', /\.less$/, 'less-loader', projectConfig.css.loaderOptions.less)
+  createCSSRule(config, 'stylus', /\.styl(us)?$/, 'stylus-loader', projectConfig.css.loaderOptions.stylus)
 
   // assets
 


### PR DESCRIPTION
I need the possibility to configure the SCSS loader options in all of my projects. I guess it is possible via chain-webpack but I couldn't get it to work. I think exposing the loader options directly makes this a lot easier.