### PR TITLE
Fix "Cannot read property 'addReference' of undefined" error

### DIFF
--- a/packages/source-wordpress/index.js
+++ b/packages/source-wordpress/index.js
@@ -95,6 +95,9 @@ class WordPressSource {
       for (const type of options.types) {
         const postTypeName = makeTypeName(type)
         const collection = getContentType(postTypeName)
+        if (!collection) {
+          continue;
+        }
 
         collection.addReference(options.rest_base, { typeName, key: '_id' })
       }


### PR DESCRIPTION
See [this issue](https://github.com/gridsome/gridsome/issues/47) for more details. Adding a guard for line 97's collection seems to fix the problem.