### PR TITLE
collection.addSchemaField fix

### DIFF
--- a/gridsome/lib/graphql/schema/nodes/createType.js
+++ b/gridsome/lib/graphql/schema/nodes/createType.js
@@ -6,6 +6,7 @@ const { refResolver } = require('../resolvers')
 
 const { nodeInterface } = require('../interfaces')
 
+const graphql = require('../../graphql')
 const {
   GraphQLID,
   GraphQLList,
@@ -13,7 +14,7 @@ const {
   GraphQLNonNull,
   GraphQLUnionType,
   GraphQLObjectType
-} = require('../../graphql')
+} = graphql
 
 module.exports = ({ contentType, nodeTypes }) => {
   const nodeType = new GraphQLObjectType({
@@ -87,7 +88,8 @@ function extendNodeType (contentType, nodeType, nodeTypes) {
       fields[fieldName] = field({
         contentType,
         nodeTypes,
-        nodeType
+        nodeType,
+        graphql
       })
     }
   }


### PR DESCRIPTION
@hjvedvik According to the documentation for `collection.addSchemaField`, the callback function should receive an object with a property of `graphql`. 

This wasn't working for me - do these modifications to the `createType.js` fix that? 