### PR TITLE
[WIP] Add siteDescription configuration

### DIFF
--- a/gridsome/app/head.js
+++ b/gridsome/app/head.js
@@ -14,7 +14,7 @@ const head = {
   title: config.siteName,
   titleTemplate: config.titleTemplate,
   __dangerouslyDisableSanitizers: ['style', 'script', 'noscript'],
-  __dangerouslyDisableSanitizersByTagID: {},
+  __dangerouslyDisableSanitizersByTagID: { description: ['content'] },
   htmlAttrs: {
     lang: 'en'
   },
@@ -22,6 +22,7 @@ const head = {
     { charset: 'utf-8' },
     { name: 'generator', content: `Gridsome v${config.version}` },
     { name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover' }
+    { vmid: 'description', name: 'description', content: config.siteDescription }
   ],
   base: {},
   noscript: [],

--- a/gridsome/lib/app/CodeGenerator.js
+++ b/gridsome/lib/app/CodeGenerator.js
@@ -81,13 +81,14 @@ async function genIcons ({ config, resolve, queue }) {
 
 function genConfig ({ config }) {
   const { version } = require('../../package.json')
-  const { siteUrl, siteName, pathPrefix, titleTemplate } = config
+  const { siteUrl, siteName, pathPrefix, titleTemplate, siteDescription } = config
 
   return `export default ${JSON.stringify({
     siteUrl,
     siteName,
     pathPrefix,
     titleTemplate,
+    siteDescription,
     version
   }, null, 2)}`
 }

--- a/gridsome/lib/app/loadConfig.js
+++ b/gridsome/lib/app/loadConfig.js
@@ -85,6 +85,7 @@ module.exports = (context, options = {}, pkg = {}) => {
   config.baseUrl = localConfig.baseUrl || '/'
   config.siteName = localConfig.siteName || path.parse(context).name
   config.titleTemplate = localConfig.titleTemplate || `%s - ${config.siteName}`
+  config.siteDescription = localConfig.siteDescription || ''
 
   config.manifestsDir = path.join(config.assetsDir, 'manifest')
   config.clientManifestPath = path.join(config.manifestsDir, 'client.json')


### PR DESCRIPTION
Configuration tell us we can set the meta description but this is a missing feature

Documentation:
https://gridsome.org/docs/config
https://deploy-preview-28--gridsome-org-live.netlify.com/docs/config

With this you set the siteDescription property :
`gridsome.config.js`
```js
module.exports = {
  ...
  siteDescription: "My super site"
  ...
}
```

WIP:
I'm stuck when using `__dangerouslyDisableSanitizersByTagID` property of vue-meta to not satanize content