### PR TITLE
feat: Add option to add tagline to homepage title [wip]

### DIFF
--- a/gridsome/app/head.js
+++ b/gridsome/app/head.js
@@ -11,7 +11,7 @@ Vue.use(Meta, {
 })
 
 const head = {
-  title: config.siteName,
+  title: config.siteTagline,
   titleTemplate: config.titleTemplate,
   __dangerouslyDisableSanitizers: ['style', 'script', 'noscript'],
   __dangerouslyDisableSanitizersByTagID: {},

--- a/gridsome/lib/app/CodeGenerator.js
+++ b/gridsome/lib/app/CodeGenerator.js
@@ -81,11 +81,12 @@ async function genIcons ({ config, resolve, queue }) {
 
 function genConfig ({ config }) {
   const { version } = require('../../package.json')
-  const { siteUrl, siteName, titleTemplate } = config
+  const { siteUrl, siteName, siteTagline, titleTemplate } = config
 
   return `export default ${JSON.stringify({
     siteUrl,
     siteName,
+    siteTagline,
     titleTemplate,
     version
   }, null, 2)}`

--- a/gridsome/lib/app/loadConfig.js
+++ b/gridsome/lib/app/loadConfig.js
@@ -90,6 +90,7 @@ module.exports = (context, options = {}, pkg = {}) => {
   config.baseUrl = localConfig.baseUrl || '/'
   config.siteName = localConfig.siteName || path.parse(context).name
   config.titleTemplate = localConfig.titleTemplate || `%s - ${config.siteName}`
+  config.siteTagline = localConfig.siteTagline || ''
 
   config.manifestsDir = path.join(config.assetsDir, 'manifest')
   config.clientManifestPath = path.join(config.manifestsDir, 'client.json')

--- a/gridsome/lib/plugins/core/index.js
+++ b/gridsome/lib/plugins/core/index.js
@@ -2,6 +2,7 @@ function corePlugin (api, options) {
   api.loadSource(store => {
     store.addMetaData('siteName', options.siteName)
     store.addMetaData('siteUrl', options.siteUrl)
+    store.addMetaData('siteTagline', options.siteTagline)
     store.addMetaData('baseUrl', options.baseUrl)
   })
 }


### PR DESCRIPTION
The default homepage title now is `Sitename - Sitename`.
It should be `Tagline - Sitename`, and if no tagline is set just `Sitename`

Todo:

- [ ] Make sure tagline is only used on homepage
- [ ] Fallback to `Sitename` only if tagline or custom vue meta title for homepage is not set.
