### PR TITLE
Fixes errors with JSON and Location content types

### DIFF
--- a/packages/source-contentful/README.md
+++ b/packages/source-contentful/README.md
@@ -30,7 +30,7 @@ module.exports = {
 @gridsome/souce-contentful currently works with all Contentful Content Types except the Rich Text [Beta] type.
 
 ### Location
-Contentful Location data is returned as JSON with `lat:` and `lon`. You will need to query the field name and each field in the GraphQL query
+Contentful Location data is returned as JSON with `lat` and `lon`. You will need to query the field name and each field in the GraphQL query
 ```
 <page-query>
 query Location{

--- a/packages/source-contentful/README.md
+++ b/packages/source-contentful/README.md
@@ -25,3 +25,44 @@ module.exports = {
   ]
 }
 ```
+
+## Contentful Content Types
+@gridsome/souce-contentful currently works with all Contentful Content Types except the Rich Text [Beta] type.
+
+### Location
+Contentful Location data is returned as JSON with `lat:` and `lon`. You will need to query the field name and each field in the GraphQL query
+```
+<page-query>
+query Location{
+  allContentfulTestType{
+    edges {
+        node{
+          geoLocation {
+            lat,
+            lon,
+          }
+        }
+      }
+    }
+  }
+</page-query>
+```
+
+### JSON
+In Contentful JSON ContentTypes, rather than recieving the entire object when querying for the field, GraphQL requires that you query for each field that you need.
+```
+<page-query>
+query Json {
+  allContentfulTestType {
+    edges {
+      node {
+        jsonFieldName{
+          itemOne,
+          itemTwo,
+        }
+      }
+    }
+  }
+}
+</page-query>
+```

--- a/packages/source-contentful/index.js
+++ b/packages/source-contentful/index.js
@@ -74,7 +74,9 @@ class ContentfulSource {
 
         if (Array.isArray(value)) {
           fields[key] = value.map(item =>
-            typeof item === 'object' ? this.createReferenceField(item) : item
+            typeof item === 'object' && typeof value.sys !== 'undefined'
+              ? this.createReferenceField(item)
+              : item
           )
         } else if (typeof value === 'object' && typeof value.sys !== 'undefined') {
           fields[key] = this.createReferenceField(value)

--- a/packages/source-contentful/index.js
+++ b/packages/source-contentful/index.js
@@ -76,7 +76,7 @@ class ContentfulSource {
           fields[key] = value.map(item =>
             typeof item === 'object' ? this.createReferenceField(item) : item
           )
-        } else if (typeof value === 'object') {
+        } else if (typeof value === 'object' && typeof value.sys !== 'undefined') {
           fields[key] = this.createReferenceField(value)
         } else {
           fields[key] = value


### PR DESCRIPTION
Adds a check for `sys` on fields that return an object before passing them to `this.createReferenceField`. Because the Location and JSON content types return objects without `sys` we can simply return the `value`

- Fixes #129
- adds examples and docs to README
