### PR TITLE
Allow index.html template to be overridden

### DIFF
--- a/gridsome/lib/app/loadConfig.js
+++ b/gridsome/lib/app/loadConfig.js
@@ -21,6 +21,7 @@ module.exports = (context, options = {}, pkg = {}) => {
   const args = options.args || {}
   const config = {}
   const plugins = []
+  const localIndex = resolve('src/index.html')
 
   const localConfig = options.localConfig
     ? options.localConfig
@@ -99,7 +100,7 @@ module.exports = (context, options = {}, pkg = {}) => {
 
   config.icon = normalizeIconsConfig(localConfig.icon)
 
-  config.templatePath = path.resolve(config.appPath, 'index.html')
+  config.templatePath = fs.existsSync(localIndex) ? localIndex : path.resolve(config.appPath, 'index.html')
   config.htmlTemplate = fs.readFileSync(config.templatePath, 'utf-8')
 
   config.scss = {}


### PR DESCRIPTION
This small PR basically allows someone to add an `index.html` to their `/src` directory and override the default template. It's probably not going to happen very often, but it's the easiest way to allow people to add CDN/external scripts to the footer of their site.