### PR TITLE
fix workbox-build version

### DIFF
--- a/packages/plugin-pwa/package.json
+++ b/packages/plugin-pwa/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "fs-extra": "^7.0.0",
     "register-service-worker": "^1.5.2",
-    "workbox-build": "^4.0.0"
+    "workbox-build": "^3.6.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
4.x is currently on alpha/beta channel and trying to npm install this plugin causes the following issue

` No matching version found for workbox-build@^4.0.0`