### PR TITLE
Added placeholder to ClientOnly

### DIFF
--- a/gridsome/app/components/ClientOnly.js
+++ b/gridsome/app/components/ClientOnly.js
@@ -1,13 +1,34 @@
 export default {
+  name: 'NoSsr',
   functional: true,
-
-  render (h, { parent, children }) {
-    if (parent._isMounted) {
-      return children
-    } else {
-      parent.$once('hook:mounted', () => {
-        parent.$forceUpdate()
-      })
+  props: {
+    placeholder: String,
+    placeholderTag: {
+      type: String,
+      default: 'div'
     }
+  },
+  render(h, { parent, slots, props }) {
+    const { default: defaultSlot = [], placeholder: placeholderSlot } = slots()
+
+    if (parent._isMounted) {
+      return defaultSlot
+    }
+
+    parent.$once('hook:mounted', () => {
+      parent.$forceUpdate()
+    })
+
+    if (props.placeholderTag && (props.placeholder || placeholderSlot)) {
+      return h(
+        props.placeholderTag,
+        {
+          class: ['clientonly']
+        },
+        props.placeholder || placeholderSlot
+      )
+    }
+    
+    return defaultSlot.length > 0 ? defaultSlot.map(() => h(false)) : h(false)
   }
 }


### PR DESCRIPTION
The placeholder is displayed until Client only component is mounted, useful when mounting component takes time

Inspired from no-ssr used by nuxt