### PR TITLE
Adds support for (existing) webp images

### DIFF
--- a/gridsome/lib/webpack/createBaseConfig.js
+++ b/gridsome/lib/webpack/createBaseConfig.js
@@ -147,7 +147,7 @@ module.exports = (app, { isProd, isServer }) => {
   // assets
 
   config.module.rule('images')
-    .test(/\.(png|jpe?g|gif)(\?.*)?$/)
+    .test(/\.(png|jpe?g|gif|webp)(\?.*)?$/)
     .use('url-loader')
     .loader('url-loader')
     .options({


### PR DESCRIPTION
This adds `webp` suffix to the webpack rule for images.