### PR TITLE
Only intercept left clicks on links

### DIFF
--- a/gridsome/app/entry.client.js
+++ b/gridsome/app/entry.client.js
@@ -21,6 +21,10 @@ document.addEventListener('click', event => {
   if (
     event.defaultPrevented ||     // disables this behavior
     event.which !== 1 ||          // not a left click
+    event.metaKey ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
     $el === null ||               // no link clicked
     $el.__gLink__ ||              // g-link anchor
     $el.hostname !== hostname ||  // external link

--- a/gridsome/app/entry.client.js
+++ b/gridsome/app/entry.client.js
@@ -20,6 +20,7 @@ document.addEventListener('click', event => {
 
   if (
     event.defaultPrevented ||     // disables this behavior
+    event.which !== 1 ||          // not a left click
     $el === null ||               // no link clicked
     $el.__gLink__ ||              // g-link anchor
     $el.hostname !== hostname ||  // external link


### PR DESCRIPTION
I often navigate documentation sites by right clicking to open a link in a new tab, but I found that this was unexpectedly causing the browser to navigate. This makes it very difficult to browse.

This pull request simply ignores any clicks that don't use the left mouse button.

I hope this is in the right place. It was the only code i could see that looked like it would be causing the behaviour I was seeing.