### PR TITLE
number of cpus defaults to 1

### DIFF
--- a/gridsome/lib/utils/sysinfo.js
+++ b/gridsome/lib/utils/sysinfo.js
@@ -6,6 +6,6 @@ module.exports = {
   cpus: {
     model: cpus.length ? cpus[0].model : '',
     logical: cpus.length,
-    physical
+    physical: physical || 1
   }
 }


### PR DESCRIPTION
physical-cpu-count depends on lscpu on linux, which is not standard in all distros (ie. alpine) and on error returns 0, which breaks the build process with a message "Expected `concurrency` to be a number from 1 and up, got `0` (number)".
This fix returns 1 if the number of cpus is 0 (may as well return cpus.length, but that would defeat the original intention)