### PR TITLE
allow OPTIONS method request to /___graphql

### DIFF
--- a/gridsome/lib/server/middlewares/graphql.js
+++ b/gridsome/lib/server/middlewares/graphql.js
@@ -9,6 +9,11 @@ const {
 
 module.exports = ({ store }) => {
   return async function (req, res, next) {
+    // allow OPTIONS method for cors
+    if (req.method === 'OPTIONS') {
+      return res.sendStatus(200)
+    }
+
     const { query, variables, ...body } = await getGraphQLParams(req)
 
     if (!query || !variables) {


### PR DESCRIPTION
#134 

When using Docker, I set host option. Unfortunately Gridsome does not work. This problem is caused by that express-graphql accepts only `GET` or `POST` http methods. This PR resolves by accepting `OPTIONS` method in Gridsome's graphql middleware.

### before
command: `gridsome develop -h 0.0.0.0`
url: `localhost:8080`
result:
<img width="826" alt="スクリーンショット 2019-03-11 18 47 29" src="https://user-images.githubusercontent.com/26014062/54114664-44810000-442e-11e9-9b30-ea7bc1294983.png">

### afrer
command: `gridsome develop -h 0.0.0.0`
url: `localhost:8080`
result:
<img width="890" alt="スクリーンショット 2019-03-11 19 01 20" src="https://user-images.githubusercontent.com/26014062/54115598-169cbb00-4430-11e9-9022-0feb419ee6e5.png">
