### PR TITLE
Support repeated path segments in dynamic routes

### DIFF
--- a/gridsome/lib/app/PluginStore.js
+++ b/gridsome/lib/app/PluginStore.js
@@ -94,12 +94,17 @@ class Source extends EventEmitter {
       routeKeys: routeKeys
         .filter(key => typeof key.name === 'string')
         .map(key => {
-          const name = key.name.replace('_raw', '')
-          const path = !NODE_FIELDS.includes(name)
-            ? ['fields'].concat(name.split('__'))
-            : [name]
+          const fieldName = key.name.replace('_raw', '')
+          const path = !NODE_FIELDS.includes(fieldName)
+            ? ['fields'].concat(fieldName.split('__'))
+            : [fieldName]
 
-          return { name, path }
+          return {
+            name: key.name,
+            path,
+            fieldName,
+            repeat: key.repeat
+          }
         }),
       resolveAbsolutePaths: options.resolveAbsolutePaths,
       mimeTypes: [],

--- a/gridsome/lib/app/__tests__/PluginStore.spec.js
+++ b/gridsome/lib/app/__tests__/PluginStore.spec.js
@@ -31,9 +31,9 @@ test('add type', () => {
   expect(contentType.options.refs).toMatchObject({})
   expect(contentType.options.fields).toMatchObject({})
   expect(contentType.options.belongsTo).toMatchObject({})
-  expect(contentType.options.routeKeys[0]).toMatchObject({ name: 'id', path: ['id'] })
-  expect(contentType.options.routeKeys[1]).toMatchObject({ name: 'bar', path: ['fields', 'bar'] })
-  expect(contentType.options.routeKeys[2]).toMatchObject({ name: 'foo', path: ['fields', 'foo'] })
+  expect(contentType.options.routeKeys[0]).toMatchObject({ name: 'id', path: ['id'], fieldName: 'id', repeat: false })
+  expect(contentType.options.routeKeys[1]).toMatchObject({ name: 'bar', path: ['fields', 'bar'], fieldName: 'bar', repeat: false })
+  expect(contentType.options.routeKeys[2]).toMatchObject({ name: 'foo_raw', path: ['fields', 'foo'], fieldName: 'foo', repeat: false })
   expect(contentType.options.resolveAbsolutePaths).toEqual(false)
 
   expect(contentType.addNode).toBeInstanceOf(Function)
@@ -307,6 +307,76 @@ test('add type with custom fields in route', () => {
   })
 
   expect(node.path).toEqual('/my-value/My%20value/1234/10/2/thriller/1/missing/lorem-ipsum')
+})
+
+test.each([
+  [
+    '/:segments+',
+    { segments: ['this', 'should be', 'SLUGIFIED'] },
+    '/this/should-be/slugified'
+  ],
+  [
+    '/:segments_raw+',
+    { segments: ['this', 'should not be', 'SLUGIFIED'] },
+    '/this/should%20not%20be/SLUGIFIED'
+  ],
+  [
+    '/path/:optionalSegments*',
+    { optionalSegments: [] },
+    '/path'
+  ],
+  [
+    '/:segments+',
+    { segments: 'this works too' },
+    '/this-works-too'
+  ],
+  [
+    '/:before*/c/:after*',
+    { before: ['a', 'b'], after: ['d'] },
+    '/a/b/c/d'
+  ],
+  [
+    '/blog/:tags*',
+    { tags: [{ typeName: 'Tag', id: 1 }, { typeName: 'Tag', id: 2 }] },
+    '/blog/1/2'
+  ],
+  [
+    '/:mixed_raw+/:mixed+',
+    { mixed: [{ typeName: 'Thing', id: 42 }, '&&&', { thisIs: 'ignored' }] },
+    '/42/%26%26%26/42/and-and-and'
+  ],
+  [
+    '/this-is/:notRepeated',
+    { notRepeated: ['a', 'b', 'c'] },
+    '/this-is/a-b-c'
+  ],
+  [
+    '/path/:segments_raw',
+    { segments: ['a', 'b', 'c'] },
+    '/path/a%2Cb%2Cc'
+  ]
+])('dynamic route with repeated segments', (route, fields, path) => {
+  const contentType = createPlugin().store.addContentType({
+    typeName: 'TestPost',
+    route
+  })
+
+  const node = contentType.addNode({ fields })
+
+  expect(node.path).toEqual(path)
+})
+
+test('dynamic route with non-optional repeated segments', () => {
+  const contentType = createPlugin().store.addContentType({
+    typeName: 'TestPost',
+    route: '/path/:segments+'
+  })
+
+  expect(() => contentType.addNode({
+    fields: {
+      segments: []
+    }
+  })).toThrow(TypeError, 'Expected "segments" to not be empty')
 })
 
 test('transform node', () => {


### PR DESCRIPTION
This fixes #277. Routes now support repeated path segments. Repeated keys with an array value are handled as expected:

```js
const examples = store.addContentType({
  typeName: 'Example',
  route: '/path/:segments+'
})

const node = examples.addNode({
  fields: {
    segments: ['a', 'b', 'c']
  }
})

console.log(node.path)
// Output: '/path/a/b/c'
```

The elements of the array are slugified unless you use the `_raw` suffix. `['foo bar', 'HELLO']` would result in `'/foo-bar/hello'` with `/:segments+` and `'/foo%20bar/HELLO'` with `/:segments_raw+`.

Note that node references also work:

```js
const node = examples.addNode({
  fields: {
    segments: [
      { typeName: 'Test', id: 1 },
      { typeName: 'Test', id: 2 }
    ]
  }
})

console.log(node.path)
// Output: '/path/1/2'
```

I tried to keep the internal changes to a minimum. Every object in the `routeKeys` array now has a `repeat` property and the original name of the key. Since the `name` property was used to hold the name of the field I renamed it to `fieldName` and used `name` to store the original name of the key.

This means that in the loop that populates the `params` object, `name` now iterates over every key name instead of every possibly duplicated field name. This removes the need for the [`&& !params[name]`](https://github.com/gridsome/gridsome/pull/279/commits/9200334c0ad0dc7d1eed9eb2ce105a204655cfa4#diff-5b4067434c16268d094326a114df9a04L303) and makes it possible to get each path segment simply by mapping over the values of the field array.