### PR TITLE
Fix field name and suffix separation

### DIFF
--- a/gridsome/lib/app/ContentTypeCollection.js
+++ b/gridsome/lib/app/ContentTypeCollection.js
@@ -287,7 +287,7 @@ class ContentTypeCollection extends EventEmitter {
     // Param values are slugified but the original
     // value will be available with '_raw' suffix.
     for (let i = 0; i < length; i++) {
-      const { name, path, fieldName, repeat } = routeKeys[i]
+      const { name, path, fieldName, repeat, suffix } = routeKeys[i]
       const field = get(node, path, fieldName)
 
       if (fieldName === 'year') params.year = date.format('YYYY')
@@ -306,7 +306,7 @@ class ContentTypeCollection extends EventEmitter {
           ) {
             return String(value.id)
           } else if (!isPlainObject(value)) {
-            return name.endsWith('_raw')
+            return suffix === 'raw'
               ? String(value)
               : this.slugify(String(value))
           } else {

--- a/gridsome/lib/app/PluginStore.js
+++ b/gridsome/lib/app/PluginStore.js
@@ -94,7 +94,11 @@ class Source extends EventEmitter {
       routeKeys: routeKeys
         .filter(key => typeof key.name === 'string')
         .map(key => {
-          const fieldName = key.name.replace('_raw', '')
+          // separate field name from suffix
+          const [, fieldName, suffix] = (
+            key.name.match(/^(.*[^_])_([a-z]+)$/) ||
+            [null, key.name, null]
+          )
           const path = !NODE_FIELDS.includes(fieldName)
             ? ['fields'].concat(fieldName.split('__'))
             : [fieldName]
@@ -103,7 +107,8 @@ class Source extends EventEmitter {
             name: key.name,
             path,
             fieldName,
-            repeat: key.repeat
+            repeat: key.repeat,
+            suffix
           }
         }),
       resolveAbsolutePaths: options.resolveAbsolutePaths,

--- a/gridsome/lib/app/__tests__/PluginStore.spec.js
+++ b/gridsome/lib/app/__tests__/PluginStore.spec.js
@@ -309,6 +309,40 @@ test('add type with custom fields in route', () => {
   expect(node.path).toEqual('/my-value/My%20value/1234/10/2/thriller/1/missing/lorem-ipsum')
 })
 
+test('deeply nested field starting with `raw`', () => {
+  const contentType = createPlugin().store.addContentType({
+    typeName: 'TestPost',
+    route: '/:foo__rawValue'
+  })
+
+  const node = contentType.addNode({
+    fields: {
+      foo: {
+        rawValue: 'BAR'
+      }
+    }
+  })
+
+  expect(node.path).toEqual('/bar')
+})
+
+test('raw version of deeply nested field starting with `raw`', () => {
+  const contentType = createPlugin().store.addContentType({
+    typeName: 'TestPost',
+    route: '/:foo__rawValue_raw'
+  })
+
+  const node = contentType.addNode({
+    fields: {
+      foo: {
+        rawValue: 'BAR'
+      }
+    }
+  })
+
+  expect(node.path).toEqual('/BAR')
+})
+
 test.each([
   [
     '/:segments+',


### PR DESCRIPTION
This fixes #294. Deeply nested field references will now work properly if the field name starts with `raw`. The field name and the suffix are now separated with a regular expression instead of removing every occurrence of `_raw` in the key with [`key.name.replace('_raw', '')`](https://github.com/vberlier/gridsome/blob/2259f85de11f0b0139d2c0cfac87c6be0217ae35/gridsome/lib/app/PluginStore.js#L97).

```js
const contentType = store.addContentType({
  typeName: 'TestPost',
  route: '/:foo__rawValue'
})

const node = contentType.addNode({
  fields: {
    foo: {
      rawValue: 'BAR'
    }
  }
})

console.log(node.path) // Output: '/bar'
```

Every element of the `routeKeys` array now has an additional `suffix` property that holds either the value of the suffix or `null` if the key doesn't have any suffix.