### PR TITLE
Support root option

### DIFF
--- a/packages/source-filesystem/index.js
+++ b/packages/source-filesystem/index.js
@@ -9,6 +9,7 @@ class FilesystemSource {
     return {
       path: undefined,
       route: undefined,
+      root: undefined,
       index: ['index'],
       typeName: 'FileNode',
       refs: {}
@@ -160,6 +161,10 @@ class FilesystemSource {
 
   createPath ({ dir, name }) {
     if (this.options.route) return
+
+    if (this.options.root) {
+      dir = dir.replace(this.options.root, '')
+    }
 
     const segments = dir.split('/').map(s => this.store.slugify(s))
 


### PR DESCRIPTION
![unknown](https://user-images.githubusercontent.com/67807/54606788-ddec8980-4aa0-11e9-8c13-9fc55e207908.png)

Example usage:

```
    {
      use: "@gridsome/source-filesystem",
      options: {
        path: "pages/**/*.yml",
        typeName: "ComponentPage",
        root: 'pages',
      }
    },
```