### PR TITLE
transformer-remark excerpt functionality

### DIFF
--- a/packages/transformer-remark/README.md
+++ b/packages/transformer-remark/README.md
@@ -15,6 +15,7 @@ module.exports = {
       externalLinksTarget: '_blank',
       externalLinksRel: ['nofollow', 'noopener', 'noreferrer'],
       anchorClassName: 'icon icon-link',
+      createExcerpt: rawContent => rawContent.split('\n')[0],
       plugins: [
         // ...global plugins
       ]
@@ -45,6 +46,11 @@ module.exports = {
 - Type: `array` Default: `[]`
 
 Add additional plugins to the parser.
+
+#### createExcerpt
+- Type: `function` Default: `undefined`
+
+Creates an excerpt from the raw markdown content.
 
 #### useBuiltIns
 

--- a/packages/transformer-remark/index.js
+++ b/packages/transformer-remark/index.js
@@ -43,10 +43,16 @@ class RemarkTransformer {
     this.toAST = unified().use(remarkParse).parse
     this.applyPlugins = unified().data('transformer', this).use(this.plugins).run
     this.toHTML = unified().use(remarkHtml).stringify
+    this.grayMatterOptions = {}
+    if ('createExcerpt' in this.options) {
+      this.grayMatterOptions.excerpt = file => {
+        file.excerpt = this.options.createExcerpt(file.content)
+      }
+    }
   }
 
   parse (source) {
-    const { data: fields, content, excerpt } = parse(source)
+    const { data: fields, content, excerpt } = parse(source, this.grayMatterOptions)
 
     // if no title was found by gray-matter,
     // try to find the first one in the content


### PR DESCRIPTION
Adds a `createExcerpt` option for transformer-remark plugin.

`excerpt` is currently in the GraphQL schema for any data created by the transformer-remark plugin.  But it is **always empty** because the plugin never passes excerpt options to gray matter.

This addresses an issue (#237) I created, and is an alternate solution to PR #284 with a more simplified API that doesn't require a user to know the gray matter package's options and their less simple excerpt function.

`createExcerpt` is just a function that accepts the raw markdown as an argument, and returns the excerpt.