### PR TITLE
Modify Article query so image url resolves

### DIFF
--- a/packages/source-drupal/README.md
+++ b/packages/source-drupal/README.md
@@ -197,7 +197,9 @@ Get the details of an individual `DrupalNodeArticle` using `<page-query>` in a G
       fieldImage {
         title,
         filename,
-        url
+        uri {
+          url
+        }
       },
       fieldTags {
         name,


### PR DESCRIPTION
This would fix a small piece of the [Drupal plugin docs](https://github.com/gridsome/gridsome/tree/master/packages/source-drupal#example-page-queries). Currently, the single Article query example throws an error, but if you change the GraphQL query to what's in the PR, it returns the file URL in fieldImage.

Before:
<img width="1218" alt="Screen Shot 2019-03-25 at 10 44 57 PM" src="https://user-images.githubusercontent.com/1531748/54968213-411e6600-4f50-11e9-8007-d28ab06e69e7.png">

After:
<img width="1220" alt="Screen Shot 2019-03-25 at 10 45 20 PM" src="https://user-images.githubusercontent.com/1531748/54968214-411e6600-4f50-11e9-869d-aa04aabe8204.png">

