### PR TITLE
Global 'click' event listener should account for port

### DIFF
--- a/gridsome/app/entry.client.js
+++ b/gridsome/app/entry.client.js
@@ -16,7 +16,7 @@ const { app, router } = createApp()
 // let Vue router handle internal URLs for anchors in innerHTML
 document.addEventListener('click', event => {
   const $el = event.target.closest('a')
-  const { hostname } = document.location
+  const { hostname, port } = document.location
 
   if (
     event.defaultPrevented ||     // disables this behavior
@@ -28,6 +28,7 @@ document.addEventListener('click', event => {
     $el === null ||               // no link clicked
     $el.__gLink__ ||              // g-link anchor
     $el.hostname !== hostname ||  // external link
+    $el.port !== port ||  // external link
     /\.[^.]+$/.test($el.pathname) // link to a file
   ) return
 


### PR DESCRIPTION
My gridsome website is deployed on `example.org`. I have a link pointing to `//examples.org:8080/foobar`.

This global 'click' event should account for the port in its test, otherwise, it mistakenly thinks this is an internal link and overrides the domain.

N.B: honestly this whole event handler seems like a terrible idea... It's easy to circumvent by right clicking on an anchor and do "Open in a new..." (tab, window, whatever) and I can see a lot of edge cases arise. People should just use `g-link`. But that's just my two cents.