### PR TITLE
WIP: Adds basic initial support for links_to_entry

### DIFF
--- a/packages/source-contentful/index.js
+++ b/packages/source-contentful/index.js
@@ -64,10 +64,17 @@ class ContentfulSource {
       const { typeName, displayField } = this.typesIndex[id]
       const collection = store.getContentType(typeName)
       const fields = {}
+      const links = await this.fetch('getEntries', {
+        links_to_entry: entry.sys.id
+      })
 
       fields.createdAt = entry.sys.createdAt
       fields.updatedAt = entry.sys.updatedAt
       fields.locale = entry.sys.locale
+
+      if (links.length > 0) {
+        fields.links = links
+      }
 
       for (const key in entry.fields) {
         const value = entry.fields[key]
@@ -95,8 +102,8 @@ class ContentfulSource {
     }
   }
 
-  async fetch (method, limit = 1000, order = 'sys.createdAt') {
-    const fetch = skip => this.client[method]({ skip, limit, order })
+  async fetch (method, params = {}, limit = 1000, order = 'sys.createdAt') {
+    const fetch = skip => this.client[method]({ skip, limit, order, ...params })
     const { total, items } = await fetch(0)
     const pages = Math.ceil(total / limit)
 


### PR DESCRIPTION
Adds support to get links to an entry using the `links_to_entry` request.
https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/links-to-entry/query-entries/console/curl

Open to suggestions on how to make this a bit better, perhaps it could use the plugin config to specify which entries to search for links since this could make a lot requests if there are a lot of entries.