### PR TITLE
Add apiKey to response fields in DatoCMS

### DIFF
--- a/packages/source-datocms/index.js
+++ b/packages/source-datocms/index.js
@@ -109,7 +109,7 @@ class DatoCmsSource {
           const val = item.readAttribute(field)
 
           if (item.itemType.hasOwnProperty('apiKey')) {
-            fields.apiKey = item.itemType.apiKey
+            fields.model = { apiKey: item.itemType.apiKey }
           }
 
           if (!val) return fields

--- a/packages/source-datocms/index.js
+++ b/packages/source-datocms/index.js
@@ -107,6 +107,11 @@ class DatoCmsSource {
         updated: new Date(item.updatedAt),
         fields: item.itemType.fields.reduce((fields, field) => {
           const val = item.readAttribute(field)
+          
+          if (item.itemType.hasOwnProperty("apiKey")) {
+            fields.apiKey = item.itemType.apiKey;
+          }
+          
           if (!val) return fields
 
           if (['link', 'links', 'rich_text'].includes(field.fieldType)) {

--- a/packages/source-datocms/index.js
+++ b/packages/source-datocms/index.js
@@ -107,11 +107,11 @@ class DatoCmsSource {
         updated: new Date(item.updatedAt),
         fields: item.itemType.fields.reduce((fields, field) => {
           const val = item.readAttribute(field)
-          
-          if (item.itemType.hasOwnProperty("apiKey")) {
-            fields.apiKey = item.itemType.apiKey;
+
+          if (item.itemType.hasOwnProperty('apiKey')) {
+            fields.apiKey = item.itemType.apiKey
           }
-          
+
           if (!val) return fields
 
           if (['link', 'links', 'rich_text'].includes(field.fieldType)) {


### PR DESCRIPTION
In graphQL it'd be great to access the `api_key` prop that Dato's JS lib provides.

The original field can be found in the [documentation](https://www.datocms.com/docs/content-management-api/resources/field).

It's very useful when using Dato's [Modular Content Blocks](https://www.datocms.com/docs/content-modelling/modular-content) as it helps identify which block type to use on the frontend.

Thanks