### PR TITLE
refactor: remove duplicate exception rethrow

### DIFF
--- a/gridsome/lib/app/queue/FileProcessQueue.js
+++ b/gridsome/lib/app/queue/FileProcessQueue.js
@@ -15,13 +15,7 @@ class FileProcessQueue {
   }
 
   async add (filePath, options = {}) {
-    let asset
-
-    try {
-      asset = await this.preProcess(filePath, options)
-    } catch (err) {
-      throw err
-    }
+    const asset = await this.preProcess(filePath, options)
 
     if (process.env.GRIDSOME_MODE === 'serve') {
       return asset

--- a/gridsome/lib/app/queue/ImageProcessQueue.js
+++ b/gridsome/lib/app/queue/ImageProcessQueue.js
@@ -21,13 +21,7 @@ class ImageProcessQueue {
   }
 
   async add (filePath, options = {}) {
-    let asset
-
-    try {
-      asset = await this.preProcess(filePath, options)
-    } catch (err) {
-      throw err
-    }
+    const asset = await this.preProcess(filePath, options)
 
     if (process.env.GRIDSOME_MODE === 'serve') {
       return asset

--- a/gridsome/lib/workers/html-writer.js
+++ b/gridsome/lib/workers/html-writer.js
@@ -22,11 +22,7 @@ exports.render = async function ({
       ? await fs.readJson(page.dataOutput)
       : undefined
 
-    try {
-      html = await render(page.path, state)
-    } catch (err) {
-      throw err
-    }
+    html = await render(page.path, state)
 
     await fs.outputFile(page.htmlOutput, html)
   }


### PR DESCRIPTION
This `catch` in some files are duplicate because they just rethrow the same exception without any handling.