### PR TITLE
fixed typo in file

### DIFF
--- a/gridsome/app/app.js
+++ b/gridsome/app/app.js
@@ -6,14 +6,14 @@ import head from './head'
 import router from './router'
 import fetchPath from './fetchPath'
 import { url } from './utils/helpers'
-import gaphqlGuard from './graphql/guard'
-import graphlMixin from './graphql/mixin'
+import graphqlGuard from './graphql/guard'
+import graphqlMixin from './graphql/mixin'
 
 import Link from './components/Link'
 import Image from './components/Image'
 import ClientOnly from './components/ClientOnly'
 
-Vue.mixin(graphlMixin)
+Vue.mixin(graphqlMixin)
 Vue.component('g-link', Link)
 Vue.component('g-image', Image)
 Vue.component('ClientOnly', ClientOnly)
@@ -21,11 +21,11 @@ Vue.component('ClientOnly', ClientOnly)
 Vue.prototype.$url = url
 Vue.prototype.$fetch = fetchPath
 
-router.beforeEach(gaphqlGuard)
+router.beforeEach(graphqlGuard)
 
 const context = {
   appOptions: {
-    render: h => h('router-view', { attrs: { id: 'app' }}),
+    render: h => h('router-view', { attrs: { id: 'app' } }),
     metaInfo: head,
     methods: {},
     data: {},
@@ -39,7 +39,7 @@ const context = {
 
 runPlugins(plugins)
 
-export function runPlugins (plugins) {
+export function runPlugins(plugins) {
   for (const { run, options } of plugins) {
     if (typeof run === 'function') {
       run(Vue, options, context)
@@ -47,13 +47,13 @@ export function runPlugins (plugins) {
   }
 }
 
-export function runMain () {
+export function runMain() {
   if (typeof main === 'function') {
     main(Vue, context)
   }
 }
 
-export default function createApp () {
+export default function createApp() {
   return {
     app: new Vue(context.appOptions),
     router


### PR DESCRIPTION
There are typos in [this file](https://github.com/gridsome/gridsome/blob/master/gridsome/app/app.js) in the spelling of "graphql". The typos do not currently cause any issues as they are utilizing default imports and the names match throughout the file. The fix passed test on my local machine.