### PR TITLE
feat(source-airtable): Add airtable source plugin

### DIFF
--- a/packages/source-airtable/README.md
+++ b/packages/source-airtable/README.md
@@ -1,0 +1,30 @@
+# @gridsome/source-datocms
+
+> Airtable source for Gridsome.
+
+## Install
+- `yarn add @gridsome/source-airtable`
+- `npm install @gridsome/source-airtable`
+
+## Usage
+
+```js
+module.exports = {
+  plugins: [
+    {
+      use: '@gridsome/source-airtable',
+      options: {
+        apiKey: 'YOUR_API_KEY', // required
+        base: 'YOUR_BASE_ID', // required
+        table: 'NAME_OF_MAIN_TABLE' // required
+      }
+    }
+  ]
+}
+```
+
+### Credentials
+
+1. `apiKey`: This can be found when logged in to airtable.com, under "ACCOUNT > API".
+1. `base`: This can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible in the url: https://airtable.com/<YOUR_BASE_ID>/api/docs#curl/introduction
+1. `table`: This is the full name of your first workspace table, for example "Furniture" is the first table in the example workspace "Product Catalog & Orders"

--- a/packages/source-airtable/README.md
+++ b/packages/source-airtable/README.md
@@ -17,7 +17,7 @@ module.exports = {
         apiKey: 'YOUR_API_KEY', // required
         base: 'YOUR_BASE_ID', // required
         route: 'YOUR_CHOSEN_ROUTE', // required
-        table: 'NAME_OF_MAIN_TABLE' // required
+        table: 'YOUR_CHOSEN_TABLE' // required
         typeName: 'YOUR_CHOSEN_TYPE_NAME' // required
       }
     }
@@ -27,8 +27,8 @@ module.exports = {
 
 ### Credentials
 
-1. `apiKey`: This can be found when logged in to airtable.com, under "ACCOUNT > API".
-1. `base`: This can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible in the url: https://airtable.com/<YOUR_BASE_ID>/api/docs#curl/introduction
-1. `route`: Your own chosen route name. The route "products" is an example of an fitting route for the pre-defined  airtable workspace named "Product Catalog & Orders"
-1. `table`: This is the full name of your first workspace table, for example "Furniture" is the first table in the pre-defined workspace named "Product Catalog & Orders"
-1. `typeName`: Your own chosen type name. The type name "Product" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"
+1. `YOUR_API_KEY`: This can be found when logged in to airtable.com, under "ACCOUNT > API".
+1. `YOUR_BASE_ID`: This can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible in the url: https://airtable.com/<YOUR_BASE_ID>/api/docs#curl/introduction
+1. `YOUR_CHOSEN_ROUTE`: Your own chosen route name. The route "products" is an example of an fitting route for the pre-defined  airtable workspace named "Product Catalog & Orders"
+1. `YOUR_CHOSEN_TABLE`: This is the full name of your chosen workspace table, for example "Furniture" is the first and main table in the pre-defined workspace named "Product Catalog & Orders"
+1. `YOUR_CHOSEN_TYPE_NAME`: Your own chosen type name. The type name "Product" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"

--- a/packages/source-airtable/README.md
+++ b/packages/source-airtable/README.md
@@ -25,10 +25,10 @@ module.exports = {
 }
 ```
 
-### Credentials
+## Options
 
-1. `YOUR_API_KEY`: This can be found when logged in to airtable.com, under "ACCOUNT > API".
-1. `YOUR_BASE_ID`: This can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible in the url: https://airtable.com/<YOUR_BASE_ID>/api/docs#curl/introduction
-1. `YOUR_TABLE_NAME`: This is the full name of your chosen workspace table, for example "Furniture" is the first and main table in the pre-defined workspace named "Product Catalog & Orders"
-1. `YOUR_TYPE_NAME`: Your chosen type name. The type name "Product" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"
-1. `YOUR_OPTIONAL_ROUTE`: Your chosen optional route name. The route "/products/:Name" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"
+1. `apiKey`: This can be found when logged in to airtable.com, under "ACCOUNT > API".
+1. `baseId`: This can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible in the url: https://airtable.com/<YOUR_BASE_ID>/api/docs#curl/introduction
+1. `tableName`: This is the full name of your chosen workspace table, for example "Furniture" is the first and main table in the pre-defined workspace named "Product Catalog & Orders"
+1. `typeName`: Your chosen type name. The type name "Product" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"
+1. `route`: Your chosen optional route name. The route "/products/:Name" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"

--- a/packages/source-airtable/README.md
+++ b/packages/source-airtable/README.md
@@ -1,4 +1,4 @@
-# @gridsome/source-datocms
+# @gridsome/source-airtable
 
 > Airtable source for Gridsome.
 

--- a/packages/source-airtable/README.md
+++ b/packages/source-airtable/README.md
@@ -31,4 +31,4 @@ module.exports = {
 1. `baseId`: This can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible in the url: https://airtable.com/<YOUR_BASE_ID>/api/docs#curl/introduction
 1. `tableName`: This is the full name of your chosen workspace table, for example "Furniture" is the first and main table in the pre-defined workspace named "Product Catalog & Orders"
 1. `typeName`: Your chosen type name. The type name "Product" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"
-1. `route`: Your chosen optional route name. The route "/products/:Name" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"
+1. `route`: Your chosen optional route name. The route "/products/:name" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"

--- a/packages/source-airtable/README.md
+++ b/packages/source-airtable/README.md
@@ -16,7 +16,9 @@ module.exports = {
       options: {
         apiKey: 'YOUR_API_KEY', // required
         base: 'YOUR_BASE_ID', // required
+        route: 'YOUR_CHOSEN_ROUTE', // required
         table: 'NAME_OF_MAIN_TABLE' // required
+        typeName: 'YOUR_CHOSEN_TYPE_NAME' // required
       }
     }
   ]
@@ -27,4 +29,6 @@ module.exports = {
 
 1. `apiKey`: This can be found when logged in to airtable.com, under "ACCOUNT > API".
 1. `base`: This can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible in the url: https://airtable.com/<YOUR_BASE_ID>/api/docs#curl/introduction
-1. `table`: This is the full name of your first workspace table, for example "Furniture" is the first table in the example workspace "Product Catalog & Orders"
+1. `route`: Your own chosen route name. The route "products" is an example of an fitting route for the pre-defined  airtable workspace named "Product Catalog & Orders"
+1. `table`: This is the full name of your first workspace table, for example "Furniture" is the first table in the pre-defined workspace named "Product Catalog & Orders"
+1. `typeName`: Your own chosen type name. The type name "Product" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"

--- a/packages/source-airtable/README.md
+++ b/packages/source-airtable/README.md
@@ -15,10 +15,10 @@ module.exports = {
       use: '@gridsome/source-airtable',
       options: {
         apiKey: 'YOUR_API_KEY', // required
-        base: 'YOUR_BASE_ID', // required
-        route: 'YOUR_CHOSEN_ROUTE', // required
-        table: 'YOUR_CHOSEN_TABLE' // required
-        typeName: 'YOUR_CHOSEN_TYPE_NAME' // required
+        baseId: 'YOUR_BASE_ID', // required
+        tableName: 'YOUR_TABLE_NAME', // required
+        typeName: 'YOUR_TYPE_NAME', // required
+        route: 'YOUR_OPTIONAL_ROUTE' // optional
       }
     }
   ]
@@ -29,6 +29,6 @@ module.exports = {
 
 1. `YOUR_API_KEY`: This can be found when logged in to airtable.com, under "ACCOUNT > API".
 1. `YOUR_BASE_ID`: This can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible in the url: https://airtable.com/<YOUR_BASE_ID>/api/docs#curl/introduction
-1. `YOUR_CHOSEN_ROUTE`: Your own chosen route name. The route "products" is an example of an fitting route for the pre-defined  airtable workspace named "Product Catalog & Orders"
-1. `YOUR_CHOSEN_TABLE`: This is the full name of your chosen workspace table, for example "Furniture" is the first and main table in the pre-defined workspace named "Product Catalog & Orders"
-1. `YOUR_CHOSEN_TYPE_NAME`: Your own chosen type name. The type name "Product" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"
+1. `YOUR_TABLE_NAME`: This is the full name of your chosen workspace table, for example "Furniture" is the first and main table in the pre-defined workspace named "Product Catalog & Orders"
+1. `YOUR_TYPE_NAME`: Your chosen type name. The type name "Product" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"
+1. `YOUR_OPTIONAL_ROUTE`: Your chosen optional route name. The route "/products/:Name" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"

--- a/packages/source-airtable/index.js
+++ b/packages/source-airtable/index.js
@@ -2,23 +2,22 @@ const Airtable = require('airtable');
 
 module.exports = function (api, options) {
     const base = new Airtable({apiKey: options.apiKey}).base(options.base);
-    const table = options.table
-    const typeName = table.replace(/ /g, '');
-    const route = typeName.toLowerCase();
+    //const table = options.table
+    //const typeName = options.typeName
+    //const route = options.route
 
     api.loadSource(async store => {
         const contentType = store.addContentType({
-            typeName: typeName,
-            // TODO: Gives me "duplicate route" error
-            route: `/${route}/:slug`
+            typeName: options.typeName,
+            route: `/${options.route}/:id`
         });
 
-        await base(table).select().eachPage((records, fetchNextPage) => {
+        await base(options.table).select().eachPage((records, fetchNextPage) => {
             records.forEach((record) => {
                 const item = record._rawJson;
                 contentType.addNode({
                     id: item.id,
-                    fields: item.fields
+                    ...item.fields
                 });
             });
             fetchNextPage();

--- a/packages/source-airtable/index.js
+++ b/packages/source-airtable/index.js
@@ -1,15 +1,15 @@
 const Airtable = require('airtable')
 
 module.exports = function (api, options) {
-  const base = new Airtable({ apiKey: options.apiKey }).base(options.base)
+  const base = new Airtable({ apiKey: options.apiKey }).base(options.baseId)
 
   api.loadSource(async store => {
     const contentType = store.addContentType({
       typeName: options.typeName,
-      route: `/${options.route}/:id`
+      route: options.route
     })
 
-    await base(options.table).select().eachPage((records, fetchNextPage) => {
+    await base(options.tableName).select().eachPage((records, fetchNextPage) => {
       records.forEach((record) => {
         const item = record._rawJson
         contentType.addNode({

--- a/packages/source-airtable/index.js
+++ b/packages/source-airtable/index.js
@@ -1,26 +1,23 @@
-const Airtable = require('airtable');
+const Airtable = require('airtable')
 
 module.exports = function (api, options) {
-    const base = new Airtable({apiKey: options.apiKey}).base(options.base);
-    //const table = options.table
-    //const typeName = options.typeName
-    //const route = options.route
+  const base = new Airtable({apiKey: options.apiKey}).base(options.base)
 
-    api.loadSource(async store => {
-        const contentType = store.addContentType({
-            typeName: options.typeName,
-            route: `/${options.route}/:id`
-        });
+  api.loadSource(async store => {
+    const contentType = store.addContentType({
+      typeName: options.typeName,
+      route: `/${options.route}/:id`
+    })
 
-        await base(options.table).select().eachPage((records, fetchNextPage) => {
-            records.forEach((record) => {
-                const item = record._rawJson;
-                contentType.addNode({
-                    id: item.id,
-                    ...item.fields
-                });
-            });
-            fetchNextPage();
-        });
-    });
-};
+    await base(options.table).select().eachPage((records, fetchNextPage) => {
+      records.forEach((record) => {
+        const item = record._rawJson
+        contentType.addNode({
+            id: item.id,
+            ...item.fields
+        })
+      })
+      fetchNextPage()
+    })
+  })
+}

--- a/packages/source-airtable/index.js
+++ b/packages/source-airtable/index.js
@@ -1,0 +1,27 @@
+const Airtable = require('airtable');
+
+module.exports = function (api, options) {
+    const base = new Airtable({apiKey: options.apiKey}).base(options.base);
+    const table = options.table
+    const typeName = table.replace(/ /g, '');
+    const route = typeName.toLowerCase();
+
+    api.loadSource(async store => {
+        const contentType = store.addContentType({
+            typeName: typeName,
+            // TODO: Gives me "duplicate route" error
+            route: `/${route}/:slug`
+        });
+
+        await base(table).select().eachPage((records, fetchNextPage) => {
+            records.forEach((record) => {
+                const item = record._rawJson;
+                contentType.addNode({
+                    id: item.id,
+                    fields: item.fields
+                });
+            });
+            fetchNextPage();
+        });
+    });
+};

--- a/packages/source-airtable/index.js
+++ b/packages/source-airtable/index.js
@@ -1,7 +1,7 @@
 const Airtable = require('airtable')
 
 module.exports = function (api, options) {
-  const base = new Airtable({apiKey: options.apiKey}).base(options.base)
+  const base = new Airtable({ apiKey: options.apiKey }).base(options.base)
 
   api.loadSource(async store => {
     const contentType = store.addContentType({
@@ -13,8 +13,8 @@ module.exports = function (api, options) {
       records.forEach((record) => {
         const item = record._rawJson
         contentType.addNode({
-            id: item.id,
-            ...item.fields
+          id: item.id,
+          ...item.fields
         })
       })
       fetchNextPage()

--- a/packages/source-airtable/index.js
+++ b/packages/source-airtable/index.js
@@ -5,6 +5,7 @@ module.exports = function (api, options) {
 
   api.loadSource(async store => {
     const contentType = store.addContentType({
+      camelCasedFieldNames: true,
       typeName: options.typeName,
       route: options.route
     })

--- a/packages/source-airtable/package.json
+++ b/packages/source-airtable/package.json
@@ -13,5 +13,8 @@
   ],
   "dependencies": {
     "airtable": "^0.6.0"
+  },
+  "engines": {
+    "node": ">=8.3"
   }
 }

--- a/packages/source-airtable/package.json
+++ b/packages/source-airtable/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@gridsome/source-airtable",
+  "version": "0.0.1",
+  "description": "Airtable source for Gridsome",
+  "homepage": "https://github.com/gridsome/gridsome/tree/master/packages/source-airtable",
+  "repository": "https://github.com/gridsome/gridsome/tree/master/packages/source-airtable#readme",
+  "main": "index.js",
+  "keywords": [
+    "gridsome",
+    "gridsome-plugin",
+    "gridsome-source",
+    "airtable"
+  ],
+  "dependencies": {
+    "airtable": "^0.6.0"
+  }
+}

--- a/packages/source-airtable/package.json
+++ b/packages/source-airtable/package.json
@@ -14,6 +14,9 @@
   "dependencies": {
     "airtable": "^0.6.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=8.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2088,6 +2088,15 @@ agentkeepalive@^3.4.1:
   dependencies:
     humanize-ms "^1.2.1"
 
+airtable@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/airtable/-/airtable-0.6.0.tgz#b29642bc2ef56ee612805599f6d502ac16818e6c"
+  integrity sha512-+5BQPQu1zUDsnlPyXPAigupxJCdXzZbUtv98jecVgis3eQRWR1Xo6oPWAVoqqTep/Z2ICVowYUUnuvHeNVE3ig==
+  dependencies:
+    lodash "4.17.11"
+    request "2.88.0"
+    xhr "2.3.3"
+
 ajv-errors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
@@ -4702,6 +4711,11 @@ dom-serializer@0.1.0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
+dom-walk@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+  integrity sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
@@ -4959,7 +4973,7 @@ error-stack-parser@^2.0.0:
   dependencies:
     stackframe "^1.0.4"
 
-es-abstract@^1.12.0, es-abstract@^1.5.1:
+es-abstract@^1.12.0, es-abstract@^1.5.0, es-abstract@^1.5.1:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
   integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
@@ -5789,6 +5803,13 @@ follow-redirects@^1.2.5, follow-redirects@^1.3.0:
   dependencies:
     debug "^3.2.6"
 
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -5934,7 +5955,7 @@ fstream@^1.0.0, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.1.1:
+function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
@@ -6170,6 +6191,14 @@ glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+global@~4.3.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
+  integrity sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=
+  dependencies:
+    min-document "^2.19.0"
+    process "~0.5.1"
 
 globals@^11.1.0, globals@^11.7.0:
   version "11.12.0"
@@ -7070,7 +7099,7 @@ is-buffer@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
   integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
-is-callable@^1.1.4:
+is-callable@^1.1.3, is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
   integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
@@ -7190,6 +7219,11 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-function@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
+  integrity sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=
 
 is-generator-fn@^2.0.0:
   version "2.1.0"
@@ -8435,6 +8469,11 @@ lodash@4.17.10:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
   integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
 
+lodash@4.17.11, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
 lodash@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
@@ -8444,11 +8483,6 @@ lodash@^3.2.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
-
-lodash@^4.11.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 log-symbols@^2.2.0:
   version "2.2.0"
@@ -8880,6 +8914,13 @@ mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
+
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
+  dependencies:
+    dom-walk "^0.1.0"
 
 mini-css-extract-plugin@^0.5.0:
   version "0.5.0"
@@ -9914,6 +9955,14 @@ parse-github-repo-url@^1.3.0:
   resolved "https://registry.yarnpkg.com/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz#9e7d8bb252a6cb6ba42595060b7bf6df3dbc1f50"
   integrity sha1-nn2LslKmy2ukJZUGC3v23z28H1A=
 
+parse-headers@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.2.tgz#9545e8a4c1ae5eaea7d24992bca890281ed26e34"
+  integrity sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==
+  dependencies:
+    for-each "^0.3.3"
+    string.prototype.trim "^1.1.2"
+
 parse-json@^2.1.0, parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
@@ -10660,6 +10709,11 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
+process@~0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+  integrity sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=
+
 progress@^2.0.0, progress@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -11379,7 +11433,7 @@ request@2.87.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-"request@>=2.76.0 <3.0.0", request@^2.83.0, request@^2.87.0, request@^2.88.0:
+request@2.88.0, "request@>=2.76.0 <3.0.0", request@^2.83.0, request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -12236,6 +12290,15 @@ string-width@^3.0.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string.prototype.trim@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
+  integrity sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.0"
+    function-bind "^1.0.2"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.2.0"
@@ -13739,6 +13802,16 @@ xdg-basedir@^2.0.0:
   integrity sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=
   dependencies:
     os-homedir "^1.0.0"
+
+xhr@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/xhr/-/xhr-2.3.3.tgz#ad6b810e0917ce72b5ec704f5d41f1503b8e7524"
+  integrity sha1-rWuBDgkXznK17HBPXUHxUDuOdSQ=
+  dependencies:
+    global "~4.3.0"
+    is-function "^1.0.1"
+    parse-headers "^2.0.0"
+    xtend "^4.0.0"
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Closes #29. Here is the first official draft of the @gridsome/source-airtable plugin. I had a version that worked, but started having issues with error relating to duplicate route names, so could not verify that this is 100% working before pushing:
`TypeName > Failed to add node: Duplicate key for property path: /<routepath>/slug`

Also had a version with class syntax, but with some issues. Decided to push simple object syntax version for now, instead of spending more time on potentially improved class syntax.

@hjvedvik please have a look and advice how to proceed in regards to "duplicate route names" issue, as well as the overall plugin.