### PR TITLE
(Drupal) Add meta from reference to referenced entity

### DIFF
--- a/packages/source-drupal/gridsome.server.js
+++ b/packages/source-drupal/gridsome.server.js
@@ -94,7 +94,11 @@ class DrupalSource {
       }
     })
 
-    await Promise.all(capturedEntities.map(entity => entity.initialize()))
+    // ensure file entities are processed last
+    const entityList = capturedEntities.slice(0);
+    entityList.sort((a, b) => (a.entityType === 'file--file') ? 1 : 0)
+
+    await Promise.all(entityList.map(entity => entity.initialize()))
   }
 }
 

--- a/packages/source-drupal/gridsome.server.js
+++ b/packages/source-drupal/gridsome.server.js
@@ -24,6 +24,7 @@ class DrupalSource {
     this.defaultExcludes = DEFAULT_EXCLUDES
     this.entities = {}
     this.apiSchema = {}
+    this.storedMeta = {}
 
     api.loadSource(store => this.initialize(store))
   }
@@ -89,7 +90,6 @@ class DrupalSource {
       if (!exclude.includes(entityType)) {
         // creating an instance of the entity class, see ./entities/*
         this.entities[entityType] = new Entity(this, { entityType, url })
-
         capturedEntities.push(this.entities[entityType])
       }
     })

--- a/packages/source-drupal/gridsome.server.js
+++ b/packages/source-drupal/gridsome.server.js
@@ -95,7 +95,7 @@ class DrupalSource {
     })
 
     // ensure file entities are processed last
-    const entityList = capturedEntities.slice(0);
+    const entityList = capturedEntities.slice(0)
     entityList.sort((a, b) => (a.entityType === 'file--file') ? 1 : 0)
 
     await Promise.all(entityList.map(entity => entity.initialize()))

--- a/packages/source-drupal/lib/Entity.js
+++ b/packages/source-drupal/lib/Entity.js
@@ -151,22 +151,21 @@ class Entity {
         result[key] = Array.isArray(data)
           ? data.map(relation => createReference(this.createTypeName(relation.type), relation.id))
           : createReference(this.createTypeName(data.type), data.id)
-      }
-
-      if (data !== null) {
+        // process any meta properties on this relationship and store them
+        // for later use on the related entity
         if (Array.isArray(data)) {
           data.map(relation => {
             if (typeof relation.meta !== 'undefined') {
               this.storedMeta[relation.id] = relation.meta
             }
           })
-        }
-        else {
+        } else {
           if (typeof data.meta !== 'undefined') {
             this.storedMeta[data.id] = data.meta
           }
         }
       }
+
       return result
     }, {})
   }


### PR DESCRIPTION
As noted in Discord:

When the image fields come through to Gridsome the alt text is lost. The alt text is in a `meta` property but only within the `relationships` property, not on an actual entity.
The JSON looks like this:
```
...
"relationships": {
  "field_image": {
    "data": {
      "type": "file--file",
      "id": "7bd4f306-a450-454d-82af-6395c342240c",
      "meta": {
        "alt": "A screenshot",
        "title": "",
        "width": 800,
        "height": 600
      }
    },
    "links": {
      "self": {
        "href": "http://back.agile.coop/api/media/image/4b2f96cf-0bcb-4d02-aa9d-617041fa1391/relationships/field_image?resourceVersion=id%3A1"
      },
      "related": {
        "href": "http://back.agile.coop/api/media/image/4b2f96cf-0bcb-4d02-aa9d-617041fa1391/field_image?resourceVersion=id%3A1"
      }
    }
  }
}
...
```
When it comes through to Gridsome the meta bit is nowhere to be seen as the relationship is only built with two properties, the type and id.

This pull request adds the meta from a reference to a temporary store and then when the referenced entity is created in GraphQL the stored meta data is added to the fields.

In practical terms this makes the alt and title fields available on the referenced node (file entity).