### PR TITLE
Fix post folder naming

### DIFF
--- a/packages/source-ghost/index.js
+++ b/packages/source-ghost/index.js
@@ -109,6 +109,7 @@ class GhostSource {
         options.primary_author = store.createReference(authorTypeName, primary_author.id)
         options.tags = tags.map(tag => store.createReference(tagTypeName, tag.id))
         options.authors = authors.map(author => store.createReference(authorTypeName, author.id))
+        options.date = options.published_at
 
         posts.addNode(options)
       })


### PR DESCRIPTION
When building connected to Ghost Source plugin the posts are put into a folder structure of `dist/Invalid date/Invalid date/Invalid date/whatever-your-slug-was`.

Adding `options.date = options.published_at` fixes that.