### PR TITLE
Fix issue #438

### DIFF
--- a/gridsome/app/directives/image.js
+++ b/gridsome/app/directives/image.js
@@ -68,19 +68,9 @@ function loadImage (el) {
     return // src is already switched
   }
 
-  const image = new Image()
-
-  image.onload = function () {
-    el.classList.remove('g-image--loading')
-    el.classList.add('g-image--loaded')
-    
-    el.src = src
-    el.sizes = sizes
-    el.srcset = srcset
-  }
-
-  image.src = src
-
-  el.classList.add('g-image--loading')
-  el.classList.remove('g-image--loaded')
+  el.srcset = srcset
+  el.sizes = sizes
+  el.src = src
+  el.classList.remove('g-image--loading')
+  el.classList.add('g-image--loaded')
 }

--- a/gridsome/app/directives/image.js
+++ b/gridsome/app/directives/image.js
@@ -67,10 +67,13 @@ function loadImage (el) {
   if (!src || el.src.endsWith(src)) {
     return // src is already switched
   }
-
+  
+  el.onload = function() {
+    el.classList.remove('g-image--loading')
+    el.classList.add('g-image--loaded')
+  }
+  
   el.srcset = srcset
   el.sizes = sizes
   el.src = src
-  el.classList.remove('g-image--loading')
-  el.classList.add('g-image--loaded')
 }


### PR DESCRIPTION
Fixed an issue where the g-image component was loading images twice.
Tested on latest browsers (edge, chrome, firefox) simulating HiDPI and iPhone 5 screens and it is working fine - a single image gets loaded on the correct width.
On IE11 the images won't load (only the pixelated SVG) but that also happens on the master branch of the base repo.