### PR TITLE
fix(pages): get correct node routes (#492)

### DIFF
--- a/gridsome/lib/plugins/vue-templates/index.js
+++ b/gridsome/lib/plugins/vue-templates/index.js
@@ -80,7 +80,7 @@ class VueTemplates {
   createNodePage (node) {
     const contentType = this.store.getContentType(node.internal.typeName)
     const component = path.join(this.templatesDir, `${node.internal.typeName}.vue`)
-    const { route } = contentType.options
+    const { route } = contentType.options.route ? contentType.options.route : {}
 
     return this.pages.createPage({
       queryVariables: node,
@@ -93,7 +93,7 @@ class VueTemplates {
   updateNodePage (node, oldNode) {
     const contentType = this.store.getContentType(node.internal.typeName)
     const component = path.join(this.templatesDir, `${node.internal.typeName}.vue`)
-    const { route } = contentType.options
+    const { route } = contentType.options.route ? contentType.options.route : {}
 
     if (node.path !== oldNode.path && !route) {
       this.removeNodePage(oldNode)


### PR DESCRIPTION
I noticed that when changing the first line in `createNodePage` the tag pages are built correctly. I assumed the same should be done in `updateNodePage`.

I don't have a full understanding of Gridsome's inner workings, so I leave it up to you to decide if this solution attempt is the correct way to solve the issue.