### PR TITLE
Optionally keep files from old build and don't process images that have already been processed

### DIFF
--- a/gridsome/index.js
+++ b/gridsome/index.js
@@ -11,8 +11,9 @@ module.exports = ({ context, program }) => {
   program
     .command('build')
     .description('build site for production')
-    .action(() => {
-      wrapCommand(require('./lib/build'))(context, {})
+    .option('-k, --keep <keep>', 'what should be kept from previous build (default: false)')
+    .action(args => {
+      wrapCommand(require('./lib/build'))(context, args)
     })
 
   program

--- a/gridsome/lib/app/loadConfig.js
+++ b/gridsome/lib/app/loadConfig.js
@@ -83,6 +83,7 @@ module.exports = (context, options = {}) => {
   config.filesDir = path.join(config.assetsDir, 'files')
   config.appPath = path.resolve(__dirname, '../../app')
   config.tmpDir = resolve('src/.temp')
+  config.buildTmpDir = resolve('./.buildTmpDir')
   config.cacheDir = resolve('.cache')
   config.dataDir = path.join(config.cacheDir, 'data')
   config.imageCacheDir = resolve('.cache', assetsDir, 'static')

--- a/gridsome/lib/workers/image-processor.js
+++ b/gridsome/lib/workers/image-processor.js
@@ -20,75 +20,76 @@ exports.processImage = async function ({
   if (cachePath && await fs.exists(cachePath)) {
     return fs.copy(cachePath, destPath)
   }
+  if (!fs.existsSync(destPath)) {
+    const { ext } = path.parse(filePath)
+    let buffer = await fs.readFile(filePath)
 
-  const { ext } = path.parse(filePath)
-  let buffer = await fs.readFile(filePath)
-
-  if (['.png', '.jpeg', '.jpg', '.webp'].includes(ext)) {
-    const config = {
-      pngCompressionLevel: parseInt(options.pngCompressionLevel, 10) || 9,
-      quality: parseInt(options.quality, 10) || 75,
-      width: parseInt(options.width, 10),
-      height: parseInt(options.height, 10),
-      jpegProgressive: true
-    }
-
-    const plugins = []
-    let pipeline = sharp(buffer)
-
-    if (config.width && config.width <= size.width) {
-      const ratio = size.height / size.width
-      const height = Math.round(config.width * ratio)
-      const resizeOptions = {}
-
-      if (options.fit) resizeOptions.fit = sharp.fit[options.fit]
-      if (options.position) resizeOptions.position = sharp.position[options.position]
-      if (options.background && colorString.get(options.background)) {
-        resizeOptions.background = options.background
-      } else if (backgroundColor) {
-        resizeOptions.background = backgroundColor
+    if (['.png', '.jpeg', '.jpg', '.webp'].includes(ext)) {
+      const config = {
+        pngCompressionLevel: parseInt(options.pngCompressionLevel, 10) || 9,
+        quality: parseInt(options.quality, 10) || 75,
+        width: parseInt(options.width, 10),
+        height: parseInt(options.height, 10),
+        jpegProgressive: true
       }
 
-      pipeline = pipeline.resize(config.width, height, resizeOptions)
+      const plugins = []
+      let pipeline = sharp(buffer)
+
+      if (config.width && config.width <= size.width) {
+        const ratio = size.height / size.width
+        const height = Math.round(config.width * ratio)
+        const resizeOptions = {}
+
+        if (options.fit) resizeOptions.fit = sharp.fit[options.fit]
+        if (options.position) resizeOptions.position = sharp.position[options.position]
+        if (options.background && colorString.get(options.background)) {
+          resizeOptions.background = options.background
+        } else if (backgroundColor) {
+          resizeOptions.background = backgroundColor
+        }
+
+        pipeline = pipeline.resize(config.width, height, resizeOptions)
+      }
+
+      if (/\.png$/.test(ext)) {
+        const quality = config.quality / 100
+
+        pipeline = pipeline.png({
+          compressionLevel: config.pngCompressionLevel,
+          adaptiveFiltering: false
+        })
+        plugins.push(imageminPngquant({
+          quality: [quality, quality]
+        }))
+      }
+
+      if (/\.jpe?g$/.test(ext)) {
+        pipeline = pipeline.jpeg({
+          progressive: config.jpegProgressive,
+          quality: config.quality
+        })
+        plugins.push(imageminMozjpeg({
+          progressive: config.jpegProgressive,
+          quality: config.quality
+        }))
+      }
+
+      if (/\.webp$/.test(ext)) {
+        pipeline = pipeline.webp({
+          quality: config.quality
+        })
+        plugins.push(imageminWebp({
+          quality: config.quality
+        }))
+      }
+
+      buffer = await pipeline.toBuffer()
+      buffer = await imagemin.buffer(buffer, { plugins })
     }
 
-    if (/\.png$/.test(ext)) {
-      const quality = config.quality / 100
-
-      pipeline = pipeline.png({
-        compressionLevel: config.pngCompressionLevel,
-        adaptiveFiltering: false
-      })
-      plugins.push(imageminPngquant({
-        quality: [quality, quality]
-      }))
-    }
-
-    if (/\.jpe?g$/.test(ext)) {
-      pipeline = pipeline.jpeg({
-        progressive: config.jpegProgressive,
-        quality: config.quality
-      })
-      plugins.push(imageminMozjpeg({
-        progressive: config.jpegProgressive,
-        quality: config.quality
-      }))
-    }
-
-    if (/\.webp$/.test(ext)) {
-      pipeline = pipeline.webp({
-        quality: config.quality
-      })
-      plugins.push(imageminWebp({
-        quality: config.quality
-      }))
-    }
-
-    buffer = await pipeline.toBuffer()
-    buffer = await imagemin.buffer(buffer, { plugins })
+    await fs.outputFile(destPath, buffer)
   }
-
-  await fs.outputFile(destPath, buffer)
 }
 
 exports.process = async function ({ queue, cacheDir, backgroundColor }) {


### PR DESCRIPTION
This PR does the following:

1) Expose the build option `--keep={directory1,directory2}` so we can optionally pass directories or files that should be kept from one build to another
2) Don't process images that have already been processed

The benefits are A and B below:

A) In combination, these two modifications allow us to save time on the build by passing the `assets` directory through the keep option.

`gridsome build --keep=assets/static`

With this command, the dist directory is cleared except for the images processed on the last build that were stored on ./dist/assets/static. These images get copied to a temporary directory and then copied back to (outDir) ./dist.
By the time image-processor.js gets to that image, it skips it since it already exists on the directory.
If you want to reprocess everything, just do gridsome build.
If you change any settings on the images being passed to <g-image> or on the graphQL query fetching the image - let's say you change the width - the hash for the file will change and the image will be processed no matter if you pass the `--keep=assets` option. The old image will be kept on ./dist/assets/static too, which leads us to item B.

B) Consider issue #488.

- Your website is live and users are browsing it.
- .html files are not cached by the browser, but users are browsing back and forth through your articles using the back button of the browser or swipe back on mobile - that means they are not reloading the html.
- A new article is published, webhook hits Netlify and your website build process starts.
- New assets get published with different hashes.
- A new user hits your website, he gets the new version, everything works fine.
- Users that were browsing your website during the publish process will get 404 errors when browsing back and forth through pages because the page data does not exist anymore on ./dist directory unless of course, they hit f5.

By allowing us to keep some files from the previous ./dist, we can work around this small issue too.

`gridsome build --keep=assets,data,js,css`

Downside is you will have more files published. Somewhere down the road, you will want to do a full `gridsome build` to clear up the ./dist. That could be ie: scheduled for Sunday at midnight.

B is mostly a consequence of A, because why not? But it kinda offers a solution to issue #488.
Also closes #494.

Looking forward for your input.