### PR TITLE
refactor: allow pass meta on route

### DIFF
--- a/gridsome/lib/pages/__tests__/pages.spec.js
+++ b/gridsome/lib/pages/__tests__/pages.spec.js
@@ -137,6 +137,18 @@ test('create page with custom route', async () => {
   expect(page.internal.isDynamic).toEqual(true)
 })
 
+test('create page with meta', async () => {
+  const { pages: { createPage }} = await createApp()
+
+  const page = createPage({
+    path: '/page',
+    component: './__fixtures__/DefaultPage.vue',
+    meta: { test: true }
+  })
+
+  expect(page.internal.meta).toMatchObject({ test: true })
+})
+
 test('allways include a /404 page', async () => {
   const app = await createApp()
   const notFound = app.pages.findPage({ path: '/404' })

--- a/gridsome/lib/pages/pages.js
+++ b/gridsome/lib/pages/pages.js
@@ -190,7 +190,7 @@ function createPage ({ options, context }) {
       digest: null,
       path: { segments },
       route: options.route || null,
-      meta: options._meta || {},
+      meta: options.meta || {},
       isDynamic: typeof options.route === 'string',
       isManaged: false
     }

--- a/gridsome/lib/pages/validateOptions.js
+++ b/gridsome/lib/pages/validateOptions.js
@@ -10,7 +10,7 @@ const schema = Joi.object()
     name: Joi.string(),
     context: Joi.object(),
     queryVariables: Joi.object(),
-    _meta: Joi.object()
+    meta: Joi.object()
   })
 
 module.exports = function vaidateOptions (options) {


### PR DESCRIPTION
Hello,
I have rename `_meta` to `meta` for allow users to add meta on route.

This can be use for add `requiresAuth`.

Thanks.