### PR TITLE
fix load config icon

### DIFF
--- a/gridsome/lib/app/loadConfig.js
+++ b/gridsome/lib/app/loadConfig.js
@@ -271,14 +271,14 @@ function normalizeIconsConfig (config = {}) {
   res.favicon = typeof icon.favicon === 'string'
     ? { src: icon.favicon, sizes: faviconSizes }
     : Object.assign({}, icon.favicon, {
-      sizes: faviconSizes,
-      src: defaultIcon
+      sizes: icon.favicon.sizes || faviconSizes,
+      src: icon.favicon.src || defaultIcon
     })
 
   res.touchicon = typeof icon.touchicon === 'string'
     ? { src: icon.touchicon, sizes: touchiconSizes, precomposed: false }
     : Object.assign({}, icon.touchicon, {
-      sizes: touchiconSizes,
+      sizes: icon.touchicon.sizes || touchiconSizes,
       src: res.favicon.src,
       precomposed: false
     })

--- a/gridsome/lib/app/loadConfig.js
+++ b/gridsome/lib/app/loadConfig.js
@@ -271,14 +271,14 @@ function normalizeIconsConfig (config = {}) {
   res.favicon = typeof icon.favicon === 'string'
     ? { src: icon.favicon, sizes: faviconSizes }
     : Object.assign({}, icon.favicon, {
-      sizes: icon.favicon.sizes || faviconSizes,
-      src: icon.favicon.src || defaultIcon
+      sizes: (icon.favicon && icon.favicon.sizes) ? icon.favicon.sizes : faviconSizes,
+      src: (icon.favicon && icon.favicon.src) ? icon.favicon.src : defaultIcon
     })
 
   res.touchicon = typeof icon.touchicon === 'string'
     ? { src: icon.touchicon, sizes: touchiconSizes, precomposed: false }
     : Object.assign({}, icon.touchicon, {
-      sizes: icon.touchicon.sizes || touchiconSizes,
+      sizes: (icon.touchicon && icon.touchicon.sizes) ? icon.touchicon.sizes : touchiconSizes,
       src: res.favicon.src,
       precomposed: false
     })

--- a/gridsome/lib/app/loadConfig.js
+++ b/gridsome/lib/app/loadConfig.js
@@ -271,15 +271,15 @@ function normalizeIconsConfig (config = {}) {
   res.favicon = typeof icon.favicon === 'string'
     ? { src: icon.favicon, sizes: faviconSizes }
     : Object.assign({}, icon.favicon, {
-      sizes: (icon.favicon && icon.favicon.sizes) ? icon.favicon.sizes : faviconSizes,
-      src: (icon.favicon && icon.favicon.src) ? icon.favicon.src : defaultIcon
+      sizes: !(icon.favicon && icon.favicon.sizes) ? faviconSizes : icon.favicon.sizes,
+      src: !(icon.favicon && icon.favicon.src) ? defaultIcon : icon.favicon.src
     })
 
   res.touchicon = typeof icon.touchicon === 'string'
     ? { src: icon.touchicon, sizes: touchiconSizes, precomposed: false }
     : Object.assign({}, icon.touchicon, {
-      sizes: (icon.touchicon && icon.touchicon.sizes) ? icon.touchicon.sizes : touchiconSizes,
-      src: res.favicon.src,
+      sizes: !(icon.touchicon && icon.touchicon.sizes) ? touchiconSizes : icon.touchicon.sizes,
+      src: !(icon.touchicon && icon.touchicon.src) ? res.favicon.src : icon.touchicon.src,
       precomposed: false
     })
 

--- a/gridsome/lib/app/loadConfig.js
+++ b/gridsome/lib/app/loadConfig.js
@@ -270,18 +270,11 @@ function normalizeIconsConfig (config = {}) {
 
   res.favicon = typeof icon.favicon === 'string'
     ? { src: icon.favicon, sizes: faviconSizes }
-    : Object.assign({}, icon.favicon, {
-      sizes: !(icon.favicon && icon.favicon.sizes) ? faviconSizes : icon.favicon.sizes,
-      src: !(icon.favicon && icon.favicon.src) ? defaultIcon : icon.favicon.src
-    })
+    : Object.assign({}, { src: defaultIcon, sizes: faviconSizes }, icon.favicon)
 
   res.touchicon = typeof icon.touchicon === 'string'
     ? { src: icon.touchicon, sizes: touchiconSizes, precomposed: false }
-    : Object.assign({}, icon.touchicon, {
-      sizes: !(icon.touchicon && icon.touchicon.sizes) ? touchiconSizes : icon.touchicon.sizes,
-      src: !(icon.touchicon && icon.touchicon.src) ? res.favicon.src : icon.touchicon.src,
-      precomposed: false
-    })
+    : Object.assign({}, { src: res.favicon.src, sizes: touchiconSizes, precomposed: false }, icon.touchicon)
 
   return res
 }


### PR DESCRIPTION
bugs: when you add custom config icon below, icon still generate default
```
module.exports = {
  icon: {
    favicon: {
      src: './src/my-favicon.png',
      sizes: [16, 32, 96, 192]
    },
    touchicon: {
      src: './src/my-touchicon.png',
      sizes: [76, 152, 120, 167],
      precomposed: true
    }
  }
}

```
then the pull request can solve it. please review it, thanks @tomtev 