### PR TITLE
Return null if date value is null or falsy

### DIFF
--- a/gridsome/lib/graphql/types/date.js
+++ b/gridsome/lib/graphql/types/date.js
@@ -24,7 +24,7 @@ exports.dateType = {
     locale: { type: GraphQLString, description: 'Locale' }
   },
   resolve: (obj, args, context, { fieldName }) => {
-    return formatDate(obj[fieldName], args)
+    return obj[fieldName] ? formatDate(obj[fieldName], args) : null
   }
 }
 
@@ -33,7 +33,7 @@ exports.dateTypeField = {
   ...exports.dateType,
   resolve: (obj, args, context, info) => {
     const value = fieldResolver(obj, args, context, info)
-    return formatDate(value, args)
+    return value ? formatDate(value, args) : null
   }
 }
 


### PR DESCRIPTION
Fixes an issue where the value for a `date` field is `null or falsy`. When `falsy or null` it shouldn't try to format the date, but rather just return null