### PR TITLE
Catch errors thrown by Sharp but don't stop processing

### DIFF
--- a/gridsome/lib/workers/image-processor.js
+++ b/gridsome/lib/workers/image-processor.js
@@ -102,6 +102,8 @@ exports.process = async function ({ queue, cacheDir, backgroundColor }) {
       backgroundColor,
       cachePath,
       ...set
+    }).catch(err => {
+      console.error(err)
     })
   }, {
     concurrency: sysinfo.cpus.logical

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "gridsome",
   "private": true,
   "workspaces": [
     "gridsome",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "gridsome",
+  "version": "0.6.6-hotfix",
   "private": true,
   "workspaces": [
     "gridsome",


### PR DESCRIPTION
Catches the following error:
```
Error: VipsJpeg: Premature end of JPEG file

(sharp:15903): GLib-CRITICAL **: 08:18:52.784: g_hash_table_lookup: assertion 'hash_table != NULL' failed
```

Instead of stopping the build, it still outputs the error, but continues processing. Useful on very large sites with 1000s of images and not knowing which one could possibly be causing the issue, but I don't really care :)