### PR TITLE
Added image download support to Wordpress Source

### DIFF
--- a/packages/source-wordpress/README.md
+++ b/packages/source-wordpress/README.md
@@ -23,7 +23,12 @@ module.exports = {
         routes: {
           post: '/:year/:month/:day/:slug',
           post_tag: '/tag/:slug'
-        }
+        },
+        splitPostsIntoFragments: true, // default false
+        downloadRemoteImagesFromPosts: true, // default false
+        postImagesLocalPath: './wp-images/',
+        downloadRemoteFeaturedImages: true, // default false
+        featuredImagesLocalPath: './wp-images/'
       }
     }
   ]
@@ -33,6 +38,42 @@ module.exports = {
 ## Use with Advanced Custom Fields
 
 Install the [ACF to REST API](https://github.com/airesvsg/acf-to-rest-api) plugin to make ACF fields available in the GraphQL schema.
+
+
+## Splitting Posts Into Fragments
+
+`splitPostsIntoFragments: true` This will expose the following on posts that you can request via GraphQL:
+
+**Query**
+```
+  postFragments {
+      type
+      fragmentData {
+          image
+          alt
+          html
+      }
+  }
+```
+
+Each fragment is either of type `img` or `html` so you can render like so:
+
+**Render**
+```
+  <template v-if="$page.wordPressPost.postFragments">
+    <template v-for="(fragment, i) in $page.wordPressPost.postFragments">
+      <!-- Fragment is a html block -->
+      <template v-if="fragment.type == 'html'">
+        <div :key="html-${i}" v-html="fragment.fragmentData.html" class="entry-content"></div>
+      </template>
+
+      <!-- Fragment is a image -->
+      <template v-if="fragment.type == 'img' && fragment.fragmentData.image">
+        <g-image :key="img-${i}" :src="fragment.fragmentData.image" :alt="fragment.fragmentData.alt"/>
+      </template>
+    </template>
+  </template>
+```
 
 ### Tips
 


### PR DESCRIPTION
Adds the following options with these defaults:

```
      splitPostsIntoFragments: false,
      downloadRemoteImagesFromPosts: false,
      postImagesLocalPath: 'wp-images/',
      downloadRemoteFeaturedImages: false,
      featuredImagesLocalPath: 'wp-images/'
```

Allows downloading of images within posts in order to process them via Gridsome.