### PR TITLE
Update Base ID Url

### DIFF
--- a/packages/source-airtable/README.md
+++ b/packages/source-airtable/README.md
@@ -28,7 +28,7 @@ module.exports = {
 ## Options
 
 1. `apiKey`: This can be found when logged in to airtable.com, under "ACCOUNT > API".
-1. `baseId`: This can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible in the url: https://airtable.com/<YOUR_BASE_ID>/api/docs#curl/introduction
+1. `baseId`: This can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible in the url: https://airtable.com/{YOUR_BASE_ID}/api/docs#curl/introduction
 1. `tableName`: This is the full name of your chosen workspace table, for example "Furniture" is the first and main table in the pre-defined workspace named "Product Catalog & Orders"
 1. `typeName`: Your chosen type name. The type name "Product" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"
 1. `route`: Your chosen optional route name. The route "/products/:name" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"


### PR DESCRIPTION
**Swap from <> to {} so that the url doesn't look like ` https://airtable.com//api/docs#curl/introduction`** 

It looks like the parser is converting `<YOUR_BASE_ID>/api/docs#curl/introduction` to `<your_base_id>/api/docs#curl/introduction</your_base_id>` on https://gridsome.org/plugins/@gridsome/source-airtable

I wasn't able to figure out how to run this locally to double check that this fixes the issue, but if someone could direct me on that, I can add it to the docs. 