### PR TITLE
add background argument to GraphQLImage

### DIFF
--- a/gridsome/lib/graphql/__tests__/nodes.spec.js
+++ b/gridsome/lib/graphql/__tests__/nodes.spec.js
@@ -860,6 +860,28 @@ test('process image types in schema', async () => {
   expect(data.testPost2.image5).toEqual('350x250.png')
 })
 
+test('set background color for contain', async () => {
+  const posts = api.store.addContentType('Post')
+
+  posts.addNode({
+    id: '1',
+    image: './350x250.png',
+    internal: {
+      origin: `${context}/assets/file.md`
+    }
+  })
+
+  const { errors, data } = await createSchemaAndExecute(`{
+    post (id: "1") {
+      image (width: 260, height: 70, fit:contain, background:"blue")
+    }
+  }`)
+
+  expect(errors).toBeUndefined()
+  expect(data.post.image.src).toEqual('/assets/static/350x250.e38261d.test.png')
+  expect(data.post.image.size).toMatchObject({ width: 260, height: 70 })
+})
+
 test('process file types in schema', async () => {
   const posts = api.store.addContentType('TestPost')
 

--- a/gridsome/lib/graphql/types/image.js
+++ b/gridsome/lib/graphql/types/image.js
@@ -5,6 +5,7 @@ const { SUPPORTED_IMAGE_TYPES } = require('../../utils/constants')
 
 const {
   GraphQLInt,
+  GraphQLString,
   GraphQLEnumType,
   GraphQLScalarType
 } = require('graphql')
@@ -70,7 +71,8 @@ exports.imageType = {
     height: { type: GraphQLInt, description: 'Height' },
     fit: { type: imageFitType, description: 'Fit', defaultValue: 'cover' },
     quality: { type: GraphQLInt, description: 'Quality (default: 75)' },
-    blur: { type: GraphQLInt, description: 'Blur level for base64 string' }
+    blur: { type: GraphQLInt, description: 'Blur level for base64 string' },
+    background: { type: GraphQLString, description: 'Background color for \'contain\''}
   },
   async resolve (obj, args, context, { fieldName }) {
     const value = obj[fieldName]


### PR DESCRIPTION
This is just a small PR that adds support for the image background argument in GraphQL queries.