### PR TITLE
Fix grapghql list resolve

### DIFF
--- a/gridsome/lib/graphql/__tests__/nodes.spec.js
+++ b/gridsome/lib/graphql/__tests__/nodes.spec.js
@@ -806,7 +806,11 @@ test('process image types in schema', async () => {
         image2: 'https://www.example.com/images/image.png',
         image3: './350x250.png',
         image4: 'dir/to/350x250.png',
-        image5: '350x250.png'
+        image5: '350x250.png',
+        images: [
+          './350x250.png',
+          './350x250.png'
+        ]
       })
     }
   })
@@ -820,7 +824,11 @@ test('process image types in schema', async () => {
         image2: 'https://www.example.com/images/image.png',
         image3: './350x250.png',
         image4: 'dir/to/350x250.png',
-        image5: '350x250.png'
+        image5: '350x250.png',
+        images: [
+          './350x250.png',
+          'https://www.example.com/images/image.png'
+        ]
       })
     }
   })
@@ -832,6 +840,7 @@ test('process image types in schema', async () => {
       image3 (width: 300, quality: 100, blur: 0)
       image4
       image5
+      images (width: 300, quality: 100, blur: 0)
     }
     testPost2: testPost (id: "2") {
       image
@@ -839,6 +848,7 @@ test('process image types in schema', async () => {
       image3 (width: 300, quality: 100, blur: 0)
       image4
       image5
+      images
     }
   }`)
 
@@ -853,11 +863,21 @@ test('process image types in schema', async () => {
   expect(data.testPost.image3.srcset).toHaveLength(1)
   expect(data.testPost.image4).toEqual('dir/to/350x250.png')
   expect(data.testPost.image5).toEqual('350x250.png')
+  expect(data.testPost.images).toHaveLength(2)
+  expect(data.testPost.images[0].type).toEqual('image')
+  expect(data.testPost.images[0].src).toEqual('/assets/static/350x250.f14e36e.test.png')
+  expect(data.testPost.images[0].size).toMatchObject({ width: 300, height: 215 })
+  expect(data.testPost.images[1].type).toEqual('image')
+  expect(data.testPost.images[1].src).toEqual('/assets/static/350x250.f14e36e.test.png')
+  expect(data.testPost.images[1].size).toMatchObject({ width: 300, height: 215 })
   expect(data.testPost2.image).toEqual('/assets/350x250.png')
   expect(data.testPost2.image2).toEqual('https://www.example.com/images/image.png')
   expect(data.testPost2.image3).toEqual('./350x250.png')
   expect(data.testPost2.image4).toEqual('dir/to/350x250.png')
   expect(data.testPost2.image5).toEqual('350x250.png')
+  expect(data.testPost2.images).toHaveLength(2)
+  expect(data.testPost2.images[0]).toEqual('./350x250.png')
+  expect(data.testPost2.images[1]).toEqual('https://www.example.com/images/image.png')
 })
 
 test('set background color for contain', async () => {

--- a/gridsome/lib/graphql/createFieldTypes.js
+++ b/gridsome/lib/graphql/createFieldTypes.js
@@ -43,8 +43,8 @@ function createFieldType (value, key, typeName, nodeTypes) {
     return type !== null ? {
       type: new GraphQLList(type.type),
       resolve: (obj, args, context, info) => {
-        const value = fieldResolver(obj, args, context, info)
-        return Array.isArray(value) ? value : []
+        const arr = fieldResolver(obj, args, context, info)
+        return arr.map((_, i) => type.resolve(arr, args, context, {...info, fieldName: i}))
       }
     } : null
   }

--- a/gridsome/lib/graphql/createFieldTypes.js
+++ b/gridsome/lib/graphql/createFieldTypes.js
@@ -42,6 +42,7 @@ function createFieldType (value, key, typeName, nodeTypes) {
 
     return type !== null ? {
       type: new GraphQLList(type.type),
+      args: type.args,
       resolve: (obj, args, context, info) => {
         const arr = fieldResolver(obj, args, context, info)
         return arr.map((_, i) => type.resolve(arr, args, context, {...info, fieldName: i}))


### PR DESCRIPTION
This PR adds support for image arrays and arrays of other custom types in GraphQL.
E.g. you can now write 

```
title: Test
images:
  - "./image1.jpg"
  - "./image2.jpg"
  - "./image3.jpg"
```


and the images will be resolved correctly, including support for arguments in GraphQL queries:

```
testPost (id: "1") {
  title
  images (width: 300, height: 300)      
}
```

