### PR TITLE
create node references for custom fields

### DIFF
--- a/packages/source-wordpress/index.js
+++ b/packages/source-wordpress/index.js
@@ -124,6 +124,7 @@ class WordPressSource {
   async getPosts (actions) {
     const { createReference } = actions
     const getCollection = actions.getCollection || actions.getContentType
+    const customPostTypeReferences = this.options.customPostTypeReferences
 
     const AUTHOR_TYPE_NAME = this.createTypeName(TYPE_AUTHOR)
     const ATTACHEMENT_TYPE_NAME = this.createTypeName(TYPE_ATTACHEMENT)
@@ -142,6 +143,15 @@ class WordPressSource {
 
         if (post.type !== TYPE_ATTACHEMENT) {
           fields.featuredMedia = createReference(ATTACHEMENT_TYPE_NAME, post.featured_media)
+        }
+
+        // create custom post field node references
+        if (customPostTypeReferences) {
+          for (let customReference of customPostTypeReferences) {
+            if (post.type !== TYPE_ATTACHEMENT && post[customReference.sourceField]) {
+              fields[customReference.targetField] = createReference(this.createTypeName(customReference.type), parseInt(post[customReference.sourceField]))
+            }
+          }
         }
 
         // add references if post has any taxonomy rest bases as properties


### PR DESCRIPTION
Adding the functionality to create node references for custom fields that contain a valid postID. It supports referencing either attachments or custom post types. References can be set on any post type, except on attachments (I didn't find a case where this would make sense, but this can be easily expanded).

Requires the `customPostTypeReferences` array to be defined in `gridsome.config.js` under the plugin settings
```
plugins: [{
    use: '@gridsome/source-wordpress',
    options: {
      baseUrl: 'https://example.com', // required
      apiBase: '?rest_route=/',
      typeName: 'WordPress',
      perPage: 100,
      concurrent: 10,
      routes: {
        post: '/:year/:month/:day/:slug',
        post_tag: '/tag/:slug'
      },
      customPostTypeReferences: [
       {
          type: 'attachment',
          sourceField: 'banner_image_id',
          targetField: 'bannerImage'
        },
        {
          type: 'car',
          sourceField: 'car_brand_id',
          targetField: 'carBrand'
        },
        ...
      ]
    }
}]
```

Example of a Query making use of a custom node reference:
```
query {
  allWordPressPost {
    edges {
      node {
        title
        bannerImage {
          id
    	  sourceUrl
          mediaDetails {
             width
          }
        }
      }
    }
  }
}
```