### PR TITLE
WordPress Source: Enh(taxonomy): add meta support

### DIFF
--- a/packages/source-wordpress/index.js
+++ b/packages/source-wordpress/index.js
@@ -115,6 +115,7 @@ class WordPressSource {
           title: term.name,
           slug: term.slug,
           content: term.description,
+          meta: term.meta,
           count: term.count
         })
       }


### PR DESCRIPTION
I suggest adding meta data to graphql for taxonomy terms. 

`add_term_meta`, `update_term_meta` and `get_term_meta` are core WordPress functions. The WP API adds a meta field by default on taxonomy terms.