### PR TITLE
feat(source-contentful): taxonomy field

### DIFF
--- a/packages/source-contentful/index.js
+++ b/packages/source-contentful/index.js
@@ -60,7 +60,7 @@ class ContentfulSource {
         const taxonomyField = this.options.taxonomy[name]
         const taxonomyTypeName = this.createTypeName(`${name} ${taxonomyField}`)
         taxonomy[taxonomyField] = actions.addCollection(taxonomyTypeName)
-        collection.addReference(taxonomyField, taxonomyTypeName);
+        collection.addReference(taxonomyField, taxonomyTypeName)
       }
 
       this.typesIndex[id] = { ...contentType, typeName, taxonomy }
@@ -102,14 +102,14 @@ class ContentfulSource {
             : item
           )
         } else if (taxonomy[key]) {
-          const taxonomyContentType = taxonomy[key];
-          let taxonomyNode = taxonomyContentType.findNode({ title: value });
+          const taxonomyContentType = taxonomy[key]
+          let taxonomyNode = taxonomyContentType.findNode({ title: value })
 
           if (taxonomyNode === null) {
-            taxonomyNode = taxonomyContentType.addNode({ title: value, id: value });
+            taxonomyNode = taxonomyContentType.addNode({ title: value, id: value })
           }
 
-          node[key] = taxonomyNode.id;
+          node[key] = taxonomyNode.id
         } else if (this.isReference(value)) {
           node[key] = this.createReference(value, actions)
         } else if (this.isRichText(value)) {


### PR DESCRIPTION
Add ability to create a taxonomy type from a specific field on a
contentful content type

For example the following config would create a type called `ContentfulBlogPostCategory` along with `ContentfulBlogPost` which can then be used to build a category page template using that type with belongsTo field in the Graphql schema.

```
{
  use: '@gridsome/source-contentful',
  options: {
    space: 'xxx',
    accessToken: 'xxx',
    host: 'cdn.contentful.com',
    environment: 'master',
    taxonomy: {
      'Blog Post': 'category'
    }
  }
}
```

I've been using this myself for a while so I thought it might be worth sharing.