### PR TITLE
feat(source-wordpress): custom REST route support for source WordPress

### DIFF
--- a/packages/source-wordpress/index.js
+++ b/packages/source-wordpress/index.js
@@ -162,7 +162,7 @@ class WordPressSource {
     for (const endpoint of this.customEndpoints) {
       const makeCollection = actions.addCollection || actions.addContentType
       const cepCollection = makeCollection({
-        typeName: endpoint.typeName,
+        typeName: endpoint.typeName
       })
       const { data } = await this.fetch(endpoint.route, {}, {})
       for (const item of data) {

--- a/packages/source-wordpress/index.js
+++ b/packages/source-wordpress/index.js
@@ -247,7 +247,7 @@ class WordPressSource {
     if (!Array.isArray(this.options.customEndpoints)) throw Error('customEndpoints must be an array')
     this.options.customEndpoints.forEach(endpoint => {
       if (!endpoint.typeName) {
-        throw Error('Please provide name option for all customEndpoints\n')
+        throw Error('Please provide typeName option for all customEndpoints\n')
       }
       if (!endpoint.route) {
         throw Error(`No route option in endpoint: ${endpoint.typeName}\n Ex: 'apiName/versionNumber/endpointObject'`)

--- a/packages/source-wordpress/index.js
+++ b/packages/source-wordpress/index.js
@@ -162,7 +162,7 @@ class WordPressSource {
     for (const endpoint of this.customEndpoints) {
       const makeCollection = actions.addCollection || actions.addContentType
       const cepCollection = makeCollection({
-        typeName: this.createTypeName(endpoint.typeName)
+        typeName: endpoint.typeName,
       })
       const { data } = await this.fetch(endpoint.route, {}, {})
       for (const item of data) {

--- a/packages/source-wordpress/index.js
+++ b/packages/source-wordpress/index.js
@@ -247,7 +247,7 @@ class WordPressSource {
     if (!Array.isArray(this.options.customEndpoints)) throw Error('customEndpoints must be an array')
     this.options.customEndpoints.forEach(endpoint => {
       if (!endpoint.typeName) {
-        throw Error('Please provide typeName option for all customEndpoints\n')
+        throw Error('Please provide a typeName option for all customEndpoints\n')
       }
       if (!endpoint.route) {
         throw Error(`No route option in endpoint: ${endpoint.typeName}\n Ex: 'apiName/versionNumber/endpointObject'`)

--- a/packages/source-wordpress/index.js
+++ b/packages/source-wordpress/index.js
@@ -162,9 +162,9 @@ class WordPressSource {
     for (const endpoint of this.customEndpoints) {
       const makeCollection = actions.addCollection || actions.addContentType
       const cepCollection = makeCollection({
-        typeName: this.createTypeName(camelCase(endpoint.name))
+        typeName: this.createTypeName(endpoint.typeName)
       })
-      const { data } = await this.fetch(`${trimEnd(endpoint.apiRoot, '/')}/${trimEnd(endpoint.apiBase, '/')}`, {}, {})
+      const { data } = await this.fetch(endpoint.route, {}, {})
       for (const item of data) {
         cepCollection.addNode({
           ...item,
@@ -246,14 +246,11 @@ class WordPressSource {
     if (!this.options.customEndpoints) return []
     if (!Array.isArray(this.options.customEndpoints)) throw Error('customEndpoints must be an array')
     this.options.customEndpoints.forEach(endpoint => {
-      if (!endpoint.name) {
+      if (!endpoint.typeName) {
         throw Error('Please provide name option for all customEndpoints\n')
       }
-      if (!endpoint.apiRoot) {
-        throw Error(`No apiRoot option in endpoint: ${endpoint.name}\n Ex: 'apiName/versionNumber'`)
-      }
-      if (!endpoint.apiBase) {
-        throw Error(`No apiBase option in endpoint: ${endpoint.name}\n Ex: 'menu'`)
+      if (!endpoint.route) {
+        throw Error(`No route option in endpoint: ${endpoint.typeName}\n Ex: 'apiName/versionNumber/endpointObject'`)
       }
     })
     return this.options.customEndpoints ? this.options.customEndpoints : []


### PR DESCRIPTION
## Summary
Adding support for user-defined REST endpoints in WordPress.

## Basic example
gridsome.config.js:
```
plugins: [
    {
      use: '@gridsome/source-wordpress',
      options: {
        baseUrl: 'http://localhost:8000',
        apiBase: 'wp-json',
        typeName: 'WordPress',
        perPage: 100,
        concurrent: 10,
        routes: {
          post: '/:slug/',
          product: '/product/:slug/'
        },
        customEndpoints: [
          {
            name: "WPMenu",
            apiRoot: "my_api/v1",
            apiBase: "menu"
          }
        ]
      }
    }
],
```
NavigationComponent.vue
```
<template>
...
</template>

<static-query>
  query Menu {
    WPMenu(id: "header") {
      menu {
        menu_items {
          title,
          url,
          menu_order
        }
      }
    }
  }
</static-query>
```

## Motivation
To pull from custom-defined REST routes you need to be able to change the standard `wp/v2` portion of the WordPress REST route to something specific to your plugin or theme.
[WordPress Reference]( https://developer.wordpress.org/reference/functions/register_rest_route/)

Works well to pull menus for example

