### PR TITLE
Remove starting slash for some Post Types 'rest_base'

### DIFF
--- a/packages/source-wordpress/index.js
+++ b/packages/source-wordpress/index.js
@@ -98,7 +98,7 @@ class WordPressSource {
         route: this.routes[type]
       })
 
-      this.restBases.taxonomies[type] = options.rest_base
+      this.restBases.taxonomies[type] = trimStart(options.rest_base, '/')
 
       const terms = await this.fetchPaged(`wp/v2/${options.rest_base}`)
 

--- a/packages/source-wordpress/index.js
+++ b/packages/source-wordpress/index.js
@@ -1,7 +1,7 @@
 const pMap = require('p-map')
 const axios = require('axios')
 const camelCase = require('camelcase')
-const { mapKeys, isPlainObject, trimEnd } = require('lodash')
+const { mapKeys, isPlainObject, trimEnd, trimStart } = require('lodash')
 
 const TYPE_AUTHOR = 'author'
 const TYPE_ATTACHEMENT = 'attachment'
@@ -56,7 +56,7 @@ class WordPressSource {
     for (const type in data) {
       const options = data[type]
 
-      this.restBases.posts[type] = options.rest_base
+      this.restBases.posts[type] = trimStart(options.rest_base, '/')
 
       addCollection({
         typeName: this.createTypeName(type),


### PR DESCRIPTION
Looks like some post types (custom post types?) have a "rest_base" starting with /. This makes the fetch request look something like <BASE_URL>/wp-json/wp/v2//api/winners which fails.

Adding trim start to `options.rest_base` should solve the double slash issue