### PR TITLE
Control prefetch/preload the links of assets

### DIFF
--- a/gridsome/lib/app/loadConfig.js
+++ b/gridsome/lib/app/loadConfig.js
@@ -142,6 +142,9 @@ module.exports = (context, options = {}) => {
 
   config.css = defaultsDeep(localConfig.css || {}, css)
 
+  config.prefetch = localConfig.prefetch || {}
+  config.preload = localConfig.preload || {}
+
   return Object.freeze(config)
 }
 

--- a/gridsome/lib/build.js
+++ b/gridsome/lib/build.js
@@ -74,7 +74,7 @@ async function renderHTML (renderQueue, app, hash) {
   const { createWorker } = require('./workers')
   const timer = hirestime()
   const worker = createWorker('html-writer')
-  const { htmlTemplate, clientManifestPath, serverBundlePath } = app.config
+  const { htmlTemplate, clientManifestPath, serverBundlePath, prefetch, preload } = app.config
 
   await Promise.all(chunk(renderQueue, 350).map(async pages => {
     try {
@@ -83,7 +83,8 @@ async function renderHTML (renderQueue, app, hash) {
         pages,
         htmlTemplate,
         clientManifestPath,
-        serverBundlePath
+        serverBundlePath,
+        prefetch, preload
       })
     } catch (err) {
       worker.end()

--- a/gridsome/lib/server/createRenderFn.js
+++ b/gridsome/lib/server/createRenderFn.js
@@ -8,7 +8,9 @@ const MAX_STATE_SIZE = 25000
 module.exports = function createRenderFn ({
   htmlTemplate,
   clientManifestPath,
-  serverBundlePath
+  serverBundlePath,
+  shouldPrefetch,
+  shouldPreload
 }) {
   const renderHTML = createHTMLRenderer(htmlTemplate)
   const clientManifest = require(clientManifestPath)
@@ -16,7 +18,9 @@ module.exports = function createRenderFn ({
 
   const renderer = createBundleRenderer(serverBundle, {
     clientManifest,
-    runInNewContext: false
+    runInNewContext: false,
+    shouldPrefetch,
+    shouldPreload
   })
 
   return async function render(page, state, stateSize, hash) {

--- a/gridsome/lib/workers/html-writer.js
+++ b/gridsome/lib/workers/html-writer.js
@@ -6,12 +6,18 @@ exports.render = async function ({
   pages,
   htmlTemplate,
   clientManifestPath,
-  serverBundlePath
+  serverBundlePath,
+  prefetch,
+  preload
 }) {
+  const regexpPrefetch = (prefetch && (typeof(prefetch.mask) === 'string')) ? new RegExp(prefetch.mask) : null
+  const regexpPreload = (preload && (typeof(preload.mask) === 'string')) ? new RegExp(preload.mask) : null
   const render = createRenderFn({
     htmlTemplate,
     clientManifestPath,
-    serverBundlePath
+    serverBundlePath,
+    shouldPrefetch: regexpPrefetch ? (file, type) => regexpPrefetch.test(file) : null,
+    shouldPreload: regexpPreload ? (file, type) => regexpPreload.test(file) : null
   })
 
   let page, html, state, stateSize

--- a/gridsome/lib/workers/html-writer.js
+++ b/gridsome/lib/workers/html-writer.js
@@ -16,8 +16,8 @@ exports.render = async function ({
     htmlTemplate,
     clientManifestPath,
     serverBundlePath,
-    shouldPrefetch: regexpPrefetch ? (file, type) => regexpPrefetch.test(file) : null,
-    shouldPreload: regexpPreload ? (file, type) => regexpPreload.test(file) : null
+    shouldPrefetch: regexpPrefetch ? file => regexpPrefetch.test(file) : null,
+    shouldPreload: regexpPreload ? file => regexpPreload.test(file) : null
   })
 
   let page, html, state, stateSize


### PR DESCRIPTION
Gridsome use vue-server-renderer for build static page. But without settings shouldPrefetch/shouldPreload.
Documentation https://ssr.vuejs.org/guide/build-config.html#client-config
Source https://github.com/vuejs/vue/blob/master/src/server/create-renderer.js#L51

**Problem**

Some sites maybe using many dynamic imports (webpack function). Default generate many-many the link of assets (for prefetch/preload). This is problem for large sites. 
```
  computed: {
    blocks() {
      return this.blocksNames.map(name => {
        const source = name
        return  () => import( /* webpackChunkName: "[request]" */ `~/components/${name}.vue` )
      })
    },
```
Page in dist (before PR)
![Before](https://user-images.githubusercontent.com/54089/65852716-ac158300-e35f-11e9-975a-0c20a58b3814.png)


**Solution**

This PR adding the functionality to control prefetch/preload the links of assets.
Also requires the object 'prefetch' (and/or 'preload') to be defined in gridsome.config.js:
```
  prefetch: {
    mask: '^$', // example - disable all prefetch 
  },
```
Page in dist (after PR)
![After](https://user-images.githubusercontent.com/54089/65852717-ac158300-e35f-11e9-922d-76d0d93fb83f.png)
