### PR TITLE
Resolve dynamic image paths with g-image

### DIFF
--- a/gridsome/app/components/Image.js
+++ b/gridsome/app/components/Image.js
@@ -13,7 +13,10 @@ export default {
     position: { type: String, default: '' },
     background: { type: String, default: '' },
     blur: { type: String, default: '' },
-    immediate: { type: true, default: undefined }
+    immediate: { type: true, default: undefined },
+    directory: { type: String, default: undefined },
+    extensions: { type: String, default: undefined },
+    deep: { type: true, default: undefined }
   },
 
   render: (h, { data, props }) => {

--- a/gridsome/lib/webpack/createBaseConfig.js
+++ b/gridsome/lib/webpack/createBaseConfig.js
@@ -89,7 +89,9 @@ module.exports = (app, { isProd, isServer }) => {
         preserveWhitespace: false,
         modules: [
           require('./modules/html')(),
-          require('./modules/assets')()
+          require('./modules/assets')({
+            defaultImageExtensions: projectConfig.imageExtensions
+          })
         ]
       },
       cacheDirectory,

--- a/gridsome/lib/webpack/modules/assets.js
+++ b/gridsome/lib/webpack/modules/assets.js
@@ -1,37 +1,66 @@
 const isUrl = require('is-url')
 const isRelative = require('is-relative')
 const { isMailtoLink, isTelLink } = require('../../utils')
+const { trimStart } = require('lodash')
 
-module.exports = () => ({
-  postTransformNode (node) {
-    if (node.tag === 'g-link') {
-      transformNodeAttr(node, 'to')
-    }
+const configAttrs = ['directory', 'extensions', 'deep']
 
-    if (node.tag === 'g-image') {
-      transformNodeAttr(node, 'src')
-    }
-  }
-})
+const isStatic = value => /^"([^"]+)?"$/.test(value)
 
-function transformNodeAttr (node, attrName) {
-  if (!Array.isArray(node.attrs)) return
+const isValidValue = value => (
+  !isUrl(value) &&
+  !isMailtoLink(value) &&
+  !isTelLink(value) &&
+  isRelative(value)
+)
 
-  for (const attr of node.attrs) {
-    if (attr.name === attrName) {
-      if (isStatic(attr.value)) {
-        attr.value = transformAttrValue(node, attr)
-        break
-      }
-    }
-  }
+const extractValue = value => value.substr(1, value.length - 2)
+
+const getAttr = (node, name) =>
+  node.attrs.find(attr => attr.name === name)
+
+const getAttrValue = (node, name) => {
+  const attr = getAttr(node, name)
+  return attr ? extractValue(attr.value) : null
 }
 
-function transformAttrValue (node, attr) {
+const createOptionsQuery = attrs => attrs
+  .filter(attr => attr.name !== 'src')
+  .filter(attr => !configAttrs.includes(attr.name))
+  .filter(attr => isStatic(attr.value))
+  .map(attr => ({ name: attr.name, value: extractValue(attr.value) }))
+  .map(attr => `${attr.name}=${encodeURIComponent(attr.value)}`)
+  .join('&')
+
+function genRequireContext (node, attr, defaultExtensions = []) {
+  const ext = (getAttrValue(node, 'extensions') || '').split(',')
+  const dir = getAttrValue(node, 'directory')
+  const value = attr.value
+  let result = attr.value
+
+  if (!ext.length) {
+    ext.push(...defaultExtensions)
+  }
+
+  const extNames = ext.map(v => trimStart(v, '.'))
+
+  if (!isStatic(value)) {
+    const query = createOptionsQuery(node.attrs)
+    const dirArg = `!!assets-loader?${query}!${dir}`
+    const subdirsArg = getAttr(node, 'deep') ? 'true' : 'false'
+    const valueArg = `"./" + (${value} || "").replace(${/^.\//}, "")`
+    const filterArg = ext.length ? new RegExp(`\\.(${extNames.join('|')})$`) : 'undefined'
+    result = `require.context("${dirArg}", ${subdirsArg}, ${filterArg})(${valueArg})`
+  }
+
+  return result
+}
+
+function genRequire (node, attr) {
   const value = extractValue(attr.value)
   let result = attr.value
 
-  if (!isUrl(value) && !isMailtoLink(value) && !isTelLink(value) && isRelative(value)) {
+  if (isValidValue(value)) {
     const query = createOptionsQuery(node.attrs)
     result = `require("!!assets-loader?${query}!${value}")`
   }
@@ -39,19 +68,42 @@ function transformAttrValue (node, attr) {
   return result
 }
 
-function isStatic (value) {
-  return /^"[^"]+"$/.test(value)
+function transformNodeAttr (node, attrName, defaultExtensions = []) {
+  if (!Array.isArray(node.attrs)) return
+
+  for (const attr of node.attrs) {
+    if (attr.name === attrName) {
+      if (isStatic(attr.value)) {
+        attr.value = genRequire(node, attr)
+        break
+      } else {
+        const directory = getAttr(node, 'directory')
+
+        if (directory) {
+          configAttrs.forEach(name => {
+            const attr = getAttr(node, name)
+            if (attr && !isStatic(attr.value)) {
+              throw new Error(`The ${name} attribute cannot be a JavaScript variable.`)
+            }
+          })
+
+          attr.value = genRequireContext(node, attr, defaultExtensions)
+          break
+        }
+      }
+    }
+  }
 }
 
-function extractValue (value) {
-  return value.substr(1, value.length - 2)
-}
+module.exports = ({ defaultImageExtensions }) => ({
+  postTransformNode (node) {
+    if (node.tag === 'g-link') {
+      transformNodeAttr(node, 'to')
+    }
 
-function createOptionsQuery (attrs) {
-  return attrs
-    .filter(attr => attr.name !== 'src')
-    .filter(attr => isStatic(attr.value))
-    .map(attr => ({ name: attr.name, value: extractValue(attr.value) }))
-    .map(attr => `${attr.name}=${encodeURIComponent(attr.value)}`)
-    .join('&')
-}
+    if (node.tag === 'g-image') {
+      transformNodeAttr(node, 'src', defaultImageExtensions)
+    }
+  }
+})
+


### PR DESCRIPTION
This PR attempts to resolve dynamic image paths with `g-image`. A `directory` attribute is required to tell webpack where to find the images. All found images in the directory with an allowed file extension will be processed by default. You can limit extensions to look for with an `extensions="png,jpg"` attribute.

```html
<template>
  <g-image directory="~/assets" :src="imagePath" />
</template>

<script>
export default {
  data: () => ({
    imagePath: 'image.png'
  })
}
</script>
```

Related: https://github.com/gridsome/gridsome/issues/292