### PR TITLE
Add join example between taxonomy term and article

### DIFF
--- a/packages/source-drupal/README.md
+++ b/packages/source-drupal/README.md
@@ -245,3 +245,29 @@ Get the details of an individual `DrupalNodeArticle` using `<page-query>` in a G
 ```
 
 Any `relationships` containing a `meta` object in the JSON:API response will be merged as a sibling object alongside `node`. See `field_image` above as an example.
+
+Taxonomy terms get a little trickier but you can use `Fragments` (and `Inline Fragments`) to generate a query that 'joins' between your node resource and your tag resource:
+
+```
+  query Tag($path: String!) {
+    tag: drupalTaxonomyTermTags(path: $path) {
+      title
+      belongsTo {
+        edges {
+          node {
+            id
+            ... on DrupalNodeArticle {
+              title
+              path
+              date_path
+              body {
+                processed
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+```
+And everything within the `DrupalNodeArticle` can be treated the same as for a regular node query.

--- a/packages/source-drupal/README.md
+++ b/packages/source-drupal/README.md
@@ -249,8 +249,8 @@ Any `relationships` containing a `meta` object in the JSON:API response will be 
 Taxonomy terms get a little trickier but you can use `Fragments` (and `Inline Fragments`) to generate a query that 'joins' between your node resource and your tag resource:
 
 ```
-  query Tag($path: String!) {
-    tag: drupalTaxonomyTermTags(path: $path) {
+  query Tag($id: String!) {
+    tag: drupalTaxonomyTermTags(id: $id) {
       title
       belongsTo {
         edges {

--- a/packages/source-drupal/README.md
+++ b/packages/source-drupal/README.md
@@ -214,7 +214,7 @@ Get the details of an individual `DrupalNodeArticle` using `<page-query>` in a G
 
 ```
 <page-query>
-  query Article($id: String!) {
+  query Article($id: ID!) {
     drupalNodeArticle(id: $id) {
       title
       date
@@ -244,12 +244,14 @@ Get the details of an individual `DrupalNodeArticle` using `<page-query>` in a G
 </page-query>
 ```
 
+Note that you can also search through the resources by other filters such are `path` (so you can lookup based on the route, for example). Remember to explore the graphql schema to better see what you can gather, what you can filter on.
+
 Any `relationships` containing a `meta` object in the JSON:API response will be merged as a sibling object alongside `node`. See `field_image` above as an example.
 
 Taxonomy terms get a little trickier but you can use `Fragments` (and `Inline Fragments`) to generate a query that 'joins' between your node resource and your tag resource:
 
 ```
-  query Tag($id: String!) {
+  query Tag($id: ID!) {
     tag: drupalTaxonomyTermTags(id: $id) {
       title
       belongsTo {


### PR DESCRIPTION
For a taxonomy term page, instead of getting all the articles and filtering them down, you can use a `Fragment` (or `Inline Fragment`) to join data between two collections. The relationship already exists thanks to JSON API so we can take advantage of that.