### PR TITLE
Break out individual Vue-Meta items for use in static rendering

### DIFF
--- a/gridsome/lib/server/createHTMLRenderer.js
+++ b/gridsome/lib/server/createHTMLRenderer.js
@@ -7,9 +7,19 @@ function createHTMLRenderer (htmlTemplate) {
     return render(Object.assign({
       htmlAttrs: '',
       bodyAttrs: '',
-      scripts: '',
       head: '',
-      app: ''
+      title: '',
+      base: '',
+      hash: '',
+      vueMetaTags: '',
+      vueMetaLinks: '',
+      resourceHints: '',
+      styles: '',
+      vueMetaStyles: '',
+      vueMetaScripts: '',
+      noscript: '',
+      app: '',
+      scripts: ''
     }, variables))
   }
 }

--- a/gridsome/lib/server/createRenderFn.js
+++ b/gridsome/lib/server/createRenderFn.js
@@ -5,7 +5,7 @@ const { error } = require('../utils/log')
 
 const MAX_STATE_SIZE = 25000
 
-module.exports = function createRenderFn ({
+module.exports = function createRenderFn({
   htmlTemplate,
   clientManifestPath,
   serverBundlePath
@@ -26,7 +26,7 @@ module.exports = function createRenderFn ({
       state: createState(state)
     }
 
-    let app = ''
+    let app = '';
 
     try {
       app = await renderer.renderToString(context)
@@ -40,23 +40,35 @@ module.exports = function createRenderFn ({
     const htmlAttrs = inject.htmlAttrs.text()
     const bodyAttrs = inject.bodyAttrs.text()
 
-    const head = '' +
-      inject.title.text() +
-      inject.base.text() +
-      `<meta name="gridsome:hash" content="${hash}">` +
-      inject.meta.text() +
-      inject.link.text() +
-      inject.style.text() +
-      inject.script.text() +
-      inject.noscript.text() +
-      context.renderResourceHints() +
-      context.renderStyles()
+    const pageTitle = inject.title.text()
+    const metaBase = inject.base.text()
+    const gridsomeHash = `<meta name="gridsome:hash" content="${hash}">`
+    const vueMetaTags = inject.meta.text()
+    const vueMetaLinks = inject.link.text()
+    const styles = context.renderStyles()
+    const noscript = inject.noscript.text()
+    const vueMetaStyles = inject.style.text()
+    const vueMetaScripts = inject.script.text()
+    const resourceHints = context.renderResourceHints()
 
-    const renderedState = state && stateSize <= MAX_STATE_SIZE
-      ? context.renderState()
-      : ''
+    const head =
+      '' +
+      pageTitle +
+      metaBase +
+      gridsomeHash +
+      vueMetaTags +
+      vueMetaLinks +
+      resourceHints +
+      styles +
+      vueMetaStyles +
+      vueMetaScripts +
+      noscript
 
-    const scripts = '' +
+    const renderedState =
+      state && stateSize <= MAX_STATE_SIZE ? context.renderState() : '';
+
+    const scripts =
+      '' +
       renderedState +
       context.renderScripts() +
       inject.script.text({ body: true })
@@ -64,14 +76,24 @@ module.exports = function createRenderFn ({
     return renderHTML({
       htmlAttrs: `data-html-server-rendered="true" ${htmlAttrs}`,
       bodyAttrs,
-      scripts,
       head,
-      app
+      title: pageTitle,
+      base: metaBase,
+      hash: gridsomeHash,
+      vueMetaTags,
+      vueMetaLinks,
+      resourceHints,
+      styles,
+      vueMetaStyles,
+      vueMetaScripts,
+      noscript,
+      app,
+      scripts
     })
-  }
+  };
 }
 
-function createState (state = {}) {
+function createState(state = {}) {
   return {
     data: state.data || null,
     context: state.context || {}

--- a/gridsome/lib/server/createRenderFn.js
+++ b/gridsome/lib/server/createRenderFn.js
@@ -5,7 +5,7 @@ const { error } = require('../utils/log')
 
 const MAX_STATE_SIZE = 25000
 
-module.exports = function createRenderFn({
+module.exports = function createRenderFn ({
   htmlTemplate,
   clientManifestPath,
   serverBundlePath
@@ -26,7 +26,7 @@ module.exports = function createRenderFn({
       state: createState(state)
     }
 
-    let app = '';
+    let app = ''
 
     try {
       app = await renderer.renderToString(context)
@@ -64,36 +64,36 @@ module.exports = function createRenderFn({
       vueMetaScripts +
       noscript
 
-    const renderedState =
-      state && stateSize <= MAX_STATE_SIZE ? context.renderState() : '';
+    const renderedState = state && stateSize <= MAX_STATE_SIZE
+      ? context.renderState()
+      : ''
 
-    const scripts =
-      '' +
+    const scripts = '' +
       renderedState +
       context.renderScripts() +
       inject.script.text({ body: true })
 
-    return renderHTML({
-      htmlAttrs: `data-html-server-rendered="true" ${htmlAttrs}`,
-      bodyAttrs,
-      head,
-      title: pageTitle,
-      base: metaBase,
-      hash: gridsomeHash,
-      vueMetaTags,
-      vueMetaLinks,
-      resourceHints,
-      styles,
-      vueMetaStyles,
-      vueMetaScripts,
-      noscript,
-      app,
-      scripts
-    })
-  };
+      return renderHTML({
+        htmlAttrs: `data-html-server-rendered="true" ${htmlAttrs}`,
+        bodyAttrs,
+        head,
+        title: pageTitle,
+        base: metaBase,
+        hash: gridsomeHash,
+        vueMetaTags,
+        vueMetaLinks,
+        resourceHints,
+        styles,
+        vueMetaStyles,
+        vueMetaScripts,
+        noscript,
+        app,
+        scripts
+      })
+  }
 }
 
-function createState(state = {}) {
+function createState (state = {}) {
   return {
     data: state.data || null,
     context: state.context || {}


### PR DESCRIPTION
Hi @hjvedvik,

We discussed via Discord a few weeks ago about further breaking out index.html template variables for use when overloading the original index.html. While I personally only needed the `gridsome:hash` broken out, I can see a need for break each out into their own template variable. 
This is my PR to do so.

We have used Gridsome to develop templates for Django (Django-templates) and breaking out these template properties will enable them to be wrapped in Django `{% block %}` statements when trying to integrate.

I look forward to your review and seeing what needs to change if any! Thanks!

---

When overloading (or replacing) the standard index.html file, a user may need to break out the various `${ head }` template variables for use in their chosen platform.

This sanely breaks out the various VueMeta props into their own template variables while retaining the original head template variable that exists currently.

Some rearrangement to the order of the head template variable has been made to group similar functionality/data.

Each new template property has been named to not interfere with current and future naming, while giving the developer implicit understanding of what that template variable exposes. The names of the template variables are up for debate or can change if need be