### PR TITLE
feat: option to skip inline blocks

### DIFF
--- a/packages/remark-prismjs/README.md
+++ b/packages/remark-prismjs/README.md
@@ -59,3 +59,24 @@ module.exports = {
   }
 }
 ```
+
+If you'd like to disable highlighting of inline code blocks, pass `skipInline: true` in the plugin options
+
+```js
+module.exports = {
+  plugins: [
+    {
+      use: '@gridsome/source-filesystem',
+      options: {}
+    }
+  ],
+
+  transformers: {
+    remark: {
+      plugins: [
+        ['@gridsome/remark-prismjs', { skipInline: true }]
+      ]
+    }
+  }
+}
+```

--- a/packages/remark-prismjs/README.md
+++ b/packages/remark-prismjs/README.md
@@ -60,7 +60,7 @@ module.exports = {
 }
 ```
 
-If you'd like to disable highlighting of inline code blocks, pass `skipInline: true` in the plugin options
+If you'd like to disable highlighting of inline code blocks, pass `transformInlineCode: false` in the plugin options
 
 ```js
 module.exports = {
@@ -74,7 +74,7 @@ module.exports = {
   transformers: {
     remark: {
       plugins: [
-        ['@gridsome/remark-prismjs', { skipInline: true }]
+        ['@gridsome/remark-prismjs', { transformInlineCode: false }]
       ]
     }
   }

--- a/packages/remark-prismjs/index.js
+++ b/packages/remark-prismjs/index.js
@@ -8,14 +8,16 @@ const toHTML = require('hast-util-to-html')
 // load all prismjs languages
 require('prismjs/components/index')()
 
-module.exports = () => tree => {
+module.exports = (options = {}) => tree => {
   visit(tree, 'code', (node, index, parent) => {
     parent.children.splice(index, 1, createCode(node))
   })
 
-  visit(tree, 'inlineCode', (node, index, parent) => {
-    parent.children.splice(index, 1, createInlineCode(node))
-  })
+  if (!options.skipInline) {
+    visit(tree, 'inlineCode', (node, index, parent) => {
+      parent.children.splice(index, 1, createInlineCode(node))
+    })
+  }
 }
 
 function highlight (node) {

--- a/packages/remark-prismjs/index.js
+++ b/packages/remark-prismjs/index.js
@@ -8,12 +8,12 @@ const toHTML = require('hast-util-to-html')
 // load all prismjs languages
 require('prismjs/components/index')()
 
-module.exports = (options = {}) => tree => {
+module.exports = (options = { transformInlineCode: true }) => tree => {
   visit(tree, 'code', (node, index, parent) => {
     parent.children.splice(index, 1, createCode(node))
   })
 
-  if (!options.skipInline) {
+  if (options.transformInlineCode) {
     visit(tree, 'inlineCode', (node, index, parent) => {
       parent.children.splice(index, 1, createInlineCode(node))
     })


### PR DESCRIPTION
This PR adds an option to disable highlighting of inline code blocks.

I've also updated the docs.

Closes #771 