### PR TITLE
Add variable disableTitleTemplate

### DIFF
--- a/gridsome/lib/app/__tests__/index.spec.js
+++ b/gridsome/lib/app/__tests__/index.spec.js
@@ -59,6 +59,17 @@ test('load env variables by NODE_ENV', () => {
   expect(process.env.PROD_VARIABLE).toEqual('PROD_2')
 })
 
+test('set custom disableTitleTemplate', () => {
+  const config = loadConfig(context, {
+    localConfig: {
+      disableTitleTemplate: true
+    }
+  })
+
+  expect(config.disableTitleTemplate).toEqual(true)
+  expect(config.titleTemplate).toEqual('')
+})
+
 test('setup custom favicon and touchicon config', () => {
   const config = loadConfig(context, {
     localConfig: {

--- a/gridsome/lib/app/loadConfig.js
+++ b/gridsome/lib/app/loadConfig.js
@@ -124,7 +124,12 @@ module.exports = (context, options = {}) => {
 
   config.siteUrl = localConfig.siteUrl || ''
   config.siteName = localConfig.siteName || path.parse(context).name
-  config.titleTemplate = localConfig.titleTemplate || `%s - ${config.siteName}`
+  config.disableTitleTemplate = localConfig.disableTitleTemplate || false
+  if (!config.disableTitleTemplate) {
+    config.titleTemplate = localConfig.titleTemplate || `%s - ${config.siteName}`
+  } else {
+    config.titleTemplate = ''
+  }
   config.siteDescription = localConfig.siteDescription || ''
   config.metadata = localConfig.metadata || {}
 


### PR DESCRIPTION
Hi @hjvedvik,
I added disableTitleTemplate to Project configuration.

Even if titleTemplate is currently empty, siteName is entered.
In a real project, you may not want to include siteName or you don't need `-`.
By using disableTitleTemplate, you can edit the title as you like.