### PR TITLE
Add item.position to collection node

### DIFF
--- a/packages/source-datocms/index.js
+++ b/packages/source-datocms/index.js
@@ -107,6 +107,7 @@ class DatoCmsSource {
         slug: slugField && item[camelize(slugField.apiKey)],
         created: new Date(item.createdAt),
         updated: new Date(item.updatedAt),
+        position: item.position,
         ...item.itemType.fields.reduce((fields, field) => {
           const val = item.readAttribute(field)
 


### PR DESCRIPTION
Adding item.position will get the sort order from the CMS.

Thanks to @matjack1 from Dato for the hot tip!