### PR TITLE
Adding customEndpoints usage to docs for source-wordpress

### DIFF
--- a/packages/source-wordpress/README.md
+++ b/packages/source-wordpress/README.md
@@ -54,7 +54,7 @@ add_filter( 'acf/format_value', function ( $value ) {
 
 ## Use Custom REST Endpoints
 
-To use REST endpoints from plugins or defined in your theme add a `customEndpoints` array to plugin options.
+To use REST endpoints from plugins or defined in your theme add a `customEndpoints` array to source-wordpress options.
 
 ```js
   use: '@gridsome/source-wordpress',

--- a/packages/source-wordpress/README.md
+++ b/packages/source-wordpress/README.md
@@ -51,3 +51,20 @@ add_filter( 'acf/format_value', function ( $value ) {
   return $value;
 }, 100 );
 ```
+
+## Use Custom REST Endpoints
+
+To use REST endpoints from plugins or defined in your theme add a `customEndpoints` array to plugin options.
+
+```js
+  use: '@gridsome/source-wordpress',
+  options: {
+    ... // other source-wordpress options
+    customEndpoints: [
+      {
+        typeName: "WPMenu",
+        route: 'myApi/v1/menus',
+      }
+    ]
+  }
+```


### PR DESCRIPTION
Updating the docs for source-wordpress to reflect `customEndpoints` option.