### PR TITLE
Adds logic to load graphql file on the basis of the "source" attribute in the <page-query> tag

### DIFF
--- a/gridsome/lib/plugins/vue-components/index.js
+++ b/gridsome/lib/plugins/vue-components/index.js
@@ -1,48 +1,73 @@
-const path = require('path')
-const compiler = require('vue-template-compiler')
-const { parse } = require('@vue/component-compiler-utils')
+const path = require("path");
+const fs = require("fs");
+const compiler = require("vue-template-compiler");
+const { parse } = require("@vue/component-compiler-utils");
 
 class VueComponents {
-  static defaultOptions () {
-    return {}
+  static defaultOptions() {
+    return {};
   }
 
-  constructor (api) {
-    api.transpileDependencies([path.resolve(__dirname, 'lib', 'loaders')])
+  constructor(api) {
+    api.transpileDependencies([path.resolve(__dirname, "lib", "loaders")]);
 
     api.chainWebpack(config => {
-      this.createGraphQLRule(config, 'page-query', './lib/loaders/page-query')
-      this.createGraphQLRule(config, 'static-query', './lib/loaders/static-query')
-    })
+      this.createGraphQLRule(config, "page-query", "./lib/loaders/page-query");
+      this.createGraphQLRule(
+        config,
+        "static-query",
+        "./lib/loaders/static-query"
+      );
+    });
 
-    api._app.pages.hooks.parseComponent.for('vue')
-      .tap('VueComponentsPlugin', (source, { resourcePath }) => {
-        const filename = path.parse(resourcePath).name
-        const { customBlocks } = parse({ filename, source, compiler })
-        const pageQuery = customBlocks.find(block => block.type === 'page-query')
+    api._app.pages.hooks.parseComponent
+      .for("vue")
+      .tap("VueComponentsPlugin", (source, { resourcePath }) => {
+        const filename = path.parse(resourcePath).name;
+        const dir = path.parse(resourcePath).dir;
+        const { customBlocks } = parse({ filename, source, compiler });
 
         return {
-          pageQuery: pageQuery ? pageQuery.content : null
-        }
-      })
+          pageQuery: this.getPageQueryContent(dir, customBlocks)
+        };
+      });
   }
 
-  createGraphQLRule (config, type, loader) {
-    const re = new RegExp(`blockType=(${type})`)
+  getPageQueryContent(templateDirectory, customBlocks) {
+    const firstPageQueryBlock = customBlocks.find(
+      block => block.type === "page-query"
+    );
+    if (firstPageQueryBlock) {
+      const hasAttributes = firstPageQueryBlock.attrs.hasOwnProperty("source");
+      const hasContent = firstPageQueryBlock.content;
+      if (hasAttributes) {
+        return fs.readFileSync(
+          path.resolve(templateDirectory, "..", "..") +
+            path.normalize(firstPageQueryBlock.attrs["source"]),
+          "utf8"
+        );
+      }
+      hasContent = hasContent.trim().length === 0 ? null : hasContent;
+      return hasContent;
+    }
+    return null;
+  }
 
-    config.module.rule(type)
+  createGraphQLRule(config, type, loader) {
+    const re = new RegExp(`blockType=(${type})`);
+
+    config.module
+      .rule(type)
       .resourceQuery(re)
-      .use('babel-loader')
-      .loader('babel-loader')
+      .use("babel-loader")
+      .loader("babel-loader")
       .options({
-        presets: [
-          require.resolve('@vue/babel-preset-app')
-        ]
+        presets: [require.resolve("@vue/babel-preset-app")]
       })
       .end()
       .use(`${type}-loader`)
-      .loader(require.resolve(loader))
+      .loader(require.resolve(loader));
   }
 }
 
-module.exports = VueComponents
+module.exports = VueComponents;

--- a/gridsome/lib/plugins/vue-components/index.js
+++ b/gridsome/lib/plugins/vue-components/index.js
@@ -1,73 +1,69 @@
-const path = require("path");
-const fs = require("fs");
-const compiler = require("vue-template-compiler");
-const { parse } = require("@vue/component-compiler-utils");
+const path = require('path')
+const fs = require('fs')
+const compiler = require('vue-template-compiler')
+const { parse } = require('@vue/component-compiler-utils')
 
 class VueComponents {
-  static defaultOptions() {
-    return {};
+  static defaultOptions () {
+    return {}
   }
 
-  constructor(api) {
-    api.transpileDependencies([path.resolve(__dirname, "lib", "loaders")]);
+  constructor (api) {
+    api.transpileDependencies([path.resolve(__dirname, 'lib', 'loaders')])
 
     api.chainWebpack(config => {
-      this.createGraphQLRule(config, "page-query", "./lib/loaders/page-query");
-      this.createGraphQLRule(
-        config,
-        "static-query",
-        "./lib/loaders/static-query"
-      );
-    });
+      this.createGraphQLRule(config, 'page-query', './lib/loaders/page-query')
+      this.createGraphQLRule(config, 'static-query', './lib/loaders/static-query')
+    })
 
-    api._app.pages.hooks.parseComponent
-      .for("vue")
-      .tap("VueComponentsPlugin", (source, { resourcePath }) => {
-        const filename = path.parse(resourcePath).name;
-        const dir = path.parse(resourcePath).dir;
-        const { customBlocks } = parse({ filename, source, compiler });
+    api._app.pages.hooks.parseComponent.for('vue')
+      .tap('VueComponentsPlugin', (source, { resourcePath }) => {
+        const filename = path.parse(resourcePath).name
+        const dir = path.parse(resourcePath).dir
+        const { customBlocks } = parse({ filename, source, compiler })
 
         return {
           pageQuery: this.getPageQueryContent(dir, customBlocks)
-        };
-      });
+        }
+      })
   }
 
-  getPageQueryContent(templateDirectory, customBlocks) {
+  getPageQueryContent (templateDirectory, customBlocks) {
     const firstPageQueryBlock = customBlocks.find(
-      block => block.type === "page-query"
-    );
+      block => block.type === 'page-query'
+    )
     if (firstPageQueryBlock) {
-      const hasAttributes = firstPageQueryBlock.attrs.hasOwnProperty("source");
-      const hasContent = firstPageQueryBlock.content;
+      const hasAttributes = firstPageQueryBlock.attrs.hasOwnProperty('source')
+      const hasContent = firstPageQueryBlock.content
       if (hasAttributes) {
         return fs.readFileSync(
-          path.resolve(templateDirectory, "..", "..") +
-            path.normalize(firstPageQueryBlock.attrs["source"]),
-          "utf8"
-        );
+          path.resolve(templateDirectory, '..', '..') +
+            path.normalize(firstPageQueryBlock.attrs['source']),
+          'utf8'
+        )
       }
-      hasContent = hasContent.trim().length === 0 ? null : hasContent;
-      return hasContent;
+      hasContent = hasContent.trim().length === 0 ? null : hasContent
+      return hasContent
     }
-    return null;
+    return null
   }
 
-  createGraphQLRule(config, type, loader) {
-    const re = new RegExp(`blockType=(${type})`);
+  createGraphQLRule (config, type, loader) {
+    const re = new RegExp(`blockType=(${type})`)
 
-    config.module
-      .rule(type)
+    config.module.rule(type)
       .resourceQuery(re)
-      .use("babel-loader")
-      .loader("babel-loader")
+      .use('babel-loader')
+      .loader('babel-loader')
       .options({
-        presets: [require.resolve("@vue/babel-preset-app")]
+        presets: [
+          require.resolve('@vue/babel-preset-app')
+        ]
       })
       .end()
       .use(`${type}-loader`)
-      .loader(require.resolve(loader));
+      .loader(require.resolve(loader))
   }
 }
 
-module.exports = VueComponents;
+module.exports = VueComponents


### PR DESCRIPTION
#796 

This is a first implementation.
When interpreting the <page-query> custom block in a Vue component it now also checks for an attribute called "source" and if that exists it will load the content of that file and use that as the GraphQL query.

I think there still can be some improvements:
* there might be a better mechanism to get the file content using webpack
* currently when there is a "source" attribute and there would be content for the <page-query> tag the logic would priotize the attribute
* error handling when the file cannot be found
* I would prefer to have an e2e test using that to ensure this functionality 

I had some problems executing the e2e tests.
Is there something I need to be aware of if I run  `npm run test:e2e` ?