### PR TITLE
feat(query): make query available to build

### DIFF
--- a/gridsome/lib/app/build/executeQueries.js
+++ b/gridsome/lib/app/build/executeQueries.js
@@ -29,8 +29,9 @@ async function executeQueries (renderQueue, { context, pages, schema, graphql },
     invariant(route, `Could not find a route for: ${entry.path}`)
     invariant(page, `Could not find a page for: ${entry.path}`)
 
-    const results = { data: null, context: page.context }
     const document = route.internal.query.document
+    const context = pages._createPageContext(page, entry.queryVariables)
+    const results = { data: null, context }
 
     if (document) {
       if (!validated.has(route.component)) {
@@ -50,9 +51,6 @@ async function executeQueries (renderQueue, { context, pages, schema, graphql },
       }
 
       results.data = data
-      results.data.query.source = route.internal.query.source
-      results.data.query.document = route.internal.query.document
-      results.data.query.variables = entry.queryVariables
     }
 
     return { dataOutput: entry.dataOutput, data: results }

--- a/gridsome/lib/app/build/executeQueries.js
+++ b/gridsome/lib/app/build/executeQueries.js
@@ -50,6 +50,9 @@ async function executeQueries (renderQueue, { context, pages, schema, graphql },
       }
 
       results.data = data
+      results.data.query.source = route.internal.query.source
+      results.data.query.document = route.internal.query.document
+      results.data.query.variables = entry.queryVariables
     }
 
     return { dataOutput: entry.dataOutput, data: results }

--- a/gridsome/lib/pages/pages.js
+++ b/gridsome/lib/pages/pages.js
@@ -10,7 +10,7 @@ const { parseQuery } = require('../graphql')
 const pathToRegexp = require('path-to-regexp')
 const createPageQuery = require('./createPageQuery')
 const { HookMap, SyncWaterfallHook, SyncBailHook } = require('tapable')
-const { snakeCase, trim, trimEnd } = require('lodash')
+const { snakeCase, trimEnd } = require('lodash')
 const validateInput = require('./schemas')
 
 const TYPE_STATIC = 'static'
@@ -352,7 +352,7 @@ class Pages {
   }
 
   _createPageContext (page, queryVariables = {}) {
-    const route = this.getRouteByPath(page.path)
+    const route = this.getRoute(page.internal.route)
     return this.hooks.pageContext.call({ ...page.context }, {
       pageQuery: route.internal.query.source,
       queryVariables

--- a/gridsome/lib/server/Server.js
+++ b/gridsome/lib/server/Server.js
@@ -50,9 +50,11 @@ class Server {
               path: variables.__path
             })
 
-            return {
-              context: page ? page.context : {}
-            }
+            const context = page
+              ? this._app.pages._createPageContext(page, variables)
+              : {}
+
+            return { context }
           }
         }
       })


### PR DESCRIPTION
Just having this as a draft for the moment.

@hjvedvik  I've got reservations making the query source and document available to the prod build by default for performance. Wondering if this should be opt in via a config setting?

Also, thinking if it's available to the static version it should be the same in development.