### PR TITLE
Do not try to read sets array if empty in ImageProcessQueue

### DIFF
--- a/gridsome/lib/app/queue/ImageProcessQueue.js
+++ b/gridsome/lib/app/queue/ImageProcessQueue.js
@@ -127,7 +127,7 @@ class ImageProcessQueue {
     })
 
     const results = {
-      src: sets[sets.length - 1].src,
+      src: sets.length != 0 ? sets[sets.length - 1].src : '',
       size: { width: imageWidth, height: imageHeight },
       width: originalSize.width,
       height: originalSize.height,


### PR DESCRIPTION
In ImageProcessQueue I get empty arrays sometime. This error blocks my building process.