### PR TITLE
fix(source-contentful): allows filtering of posts by reference child fields

### DIFF
--- a/packages/source-contentful/index.js
+++ b/packages/source-contentful/index.js
@@ -132,7 +132,10 @@ class ContentfulSource {
         const contentType = this.typesIndex[item.sys.contentType.sys.id]
         const typeName = this.createTypeName(contentType.name)
 
-        return store.createReference(typeName, item.sys.id)
+        return {
+          ...store.createReference(typeName, item.sys.id),
+          ...item.fields
+        }
     }
   }
 


### PR DESCRIPTION
See #852. This PR allows filtering of Contentful posts by reference fields other than ID.