### PR TITLE
Allow users to pass select options object to Airtable's queries

### DIFF
--- a/packages/source-airtable/README.md
+++ b/packages/source-airtable/README.md
@@ -18,18 +18,20 @@ module.exports = {
         baseId: 'YOUR_BASE_ID', // required
         tableName: 'YOUR_TABLE_NAME', // required
         typeName: 'YOUR_TYPE_NAME', // required
-      }
-    }
+        select: {}, // optional
+      },
+    },
   ],
   templates: {
-    YOUR_TYPE_NAME: 'YOUR_OPTIONAL_ROUTE' // optional
-  }
+    YOUR_TYPE_NAME: 'YOUR_OPTIONAL_ROUTE', // optional
+  },
 }
 ```
 
 ## Options
 
-1. `apiKey`: This can be found when logged in to airtable.com, under "ACCOUNT > API".
+1. `apiKey`: This can be found when logged in to airtable.com, under "ACCOUNT > API"
 1. `baseId`: This can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible in the url: https://airtable.com/{YOUR_BASE_ID}/api/docs#curl/introduction
 1. `tableName`: This is the full name of your chosen workspace table, for example "Furniture" is the first and main table in the pre-defined workspace named "Product Catalog & Orders"
 1. `typeName`: Your chosen type name. The type name "Product" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"
+1. `select`: Your select options. These can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible under the _List records_ of your table

--- a/packages/source-airtable/index.js
+++ b/packages/source-airtable/index.js
@@ -12,15 +12,17 @@ module.exports = function (api, options) {
       route: options.route
     })
 
-    await base(options.tableName).select().eachPage((records, fetchNextPage) => {
-      records.forEach((record) => {
-        const item = record._rawJson
-        collection.addNode({
-          id: item.id,
-          ...item.fields
+    await base(options.tableName)
+      .select(options.select || {})
+      .eachPage((records, fetchNextPage) => {
+        records.forEach((record) => {
+          const item = record._rawJson
+          collection.addNode({
+            id: item.id,
+            ...item.fields
+          })
         })
+        fetchNextPage()
       })
-      fetchNextPage()
-    })
   })
 }


### PR DESCRIPTION
Airtable requires you to specify a `view` if you want to get your records in the order specified there. This PR adds support for passing this select option object and defaults to an empty one to make it work the same way it did before.