### PR TITLE
Use webpack watchOptions config for webpack-dev-middleware

### DIFF
--- a/gridsome/lib/develop.js
+++ b/gridsome/lib/develop.js
@@ -38,6 +38,7 @@ module.exports = async (context, args) => {
   server.hooks.afterSetup.tap('develop', server => {
     const devMiddleware = require('webpack-dev-middleware')(compiler, {
       pathPrefix: webpackConfig.output.pathPrefix,
+      watchOptions: webpackConfig.devServer ? webpackConfig.devServer.watchOptions : null,
       logLevel: 'silent'
     })
 


### PR DESCRIPTION
Setting `configureWebpack.devServer.watchOptions` is currently passed to webpack, but actually needs to be set on the middleware to have effect. 
`watchOptions` is needed to enable polling, which is required when running gridsome in a Docker for Windows container. 