### PR TITLE
fix(source-contentful): properly handle empty asset fields

### DIFF
--- a/packages/source-contentful/index.js
+++ b/packages/source-contentful/index.js
@@ -74,7 +74,7 @@ class ContentfulSource {
 
     for (const entry of entries) {
       const typeId = entry.sys.contentType.sys.id
-      const { typeName, displayField } = this.typesIndex[typeId]
+      const { typeName, displayField, fields } = this.typesIndex[typeId]
       const collection = actions.getCollection(typeName)
       const node = {}
 
@@ -84,7 +84,8 @@ class ContentfulSource {
       node.updatedAt = entry.sys.updatedAt
       node.locale = entry.sys.locale
 
-      for (const key in entry.fields) {
+      for (const idx in fields) {
+        const key = fields[idx].id;
         const value = entry.fields[key]
 
         if (Array.isArray(value)) {

--- a/packages/source-contentful/index.js
+++ b/packages/source-contentful/index.js
@@ -85,7 +85,7 @@ class ContentfulSource {
       node.locale = entry.sys.locale
 
       for (const idx in fields) {
-        const key = fields[idx].id;
+        const key = fields[idx].id
         const value = entry.fields[key]
 
         if (Array.isArray(value)) {


### PR DESCRIPTION
Iterate based on the fields on the schema, so we can catch the missing fields. Closes #864.