### PR TITLE
feat(source-ghost) upgrade content-api to support Ghost v3

### DIFF
--- a/packages/source-ghost/package.json
+++ b/packages/source-ghost/package.json
@@ -12,7 +12,7 @@
     "ghost"
   ],
   "dependencies": {
-    "@tryghost/content-api": "^1.2.2",
+    "@tryghost/content-api": "^1.3.4",
     "camelcase": "^5.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
Updated the `@tryghost/content-api` package. Closes #867.