### PR TITLE
fix(source-ghost) add explicit schemas for ghost types

### DIFF
--- a/packages/source-ghost/ghost-schema.js
+++ b/packages/source-ghost/ghost-schema.js
@@ -1,4 +1,4 @@
-const GhostAuthor = ({author}) => `type ${author} implements Node {
+const GhostAuthor = ({ author }) => `type ${author} implements Node {
   id: ID!
   name: String
   slug: String
@@ -14,7 +14,7 @@ const GhostAuthor = ({author}) => `type ${author} implements Node {
   url: String
   postCount: Int
 }`
-const GhostTag = ({tag}) => `type ${tag} implements Node {
+const GhostTag = ({ tag }) => `type ${tag} implements Node {
   id: ID!
   name: String
   slug: String
@@ -27,7 +27,7 @@ const GhostTag = ({tag}) => `type ${tag} implements Node {
   url: String
   visibility: String
 }`
-const GhostPost = ({post, author, tag}) => `type ${post} implements Node {
+const GhostPost = ({ post, author, tag }) => `type ${post} implements Node {
   id: ID!
   uuid: String
   title: String
@@ -62,7 +62,7 @@ const GhostPost = ({post, author, tag}) => `type ${post} implements Node {
   mobiledoc: String
   codeinjection_styles: String
 }`
-const GhostPage = ({page, author, tag}) => `type ${page} implements Node {
+const GhostPage = ({ page, author, tag }) => `type ${page} implements Node {
   id: ID!
   uuid: String
   title: String

--- a/packages/source-ghost/ghost-schema.js
+++ b/packages/source-ghost/ghost-schema.js
@@ -1,0 +1,107 @@
+const GhostAuthor = ({author}) => `type ${author} implements Node {
+  id: ID!
+  name: String
+  slug: String
+  profile_image: String
+  cover_image: String
+  bio: String
+  website: String
+  location: String
+  facebook: String
+  twitter: String
+  meta_title: String
+  meta_description: String
+  url: String
+  postCount: Int
+}`
+const GhostTag = ({tag}) => `type ${tag} implements Node {
+  id: ID!
+  name: String
+  slug: String
+  description: String
+  feature_image: String
+  ghostId: String
+  meta_description: String
+  meta_title: String
+  postCount: Int
+  url: String
+  visibility: String
+}`
+const GhostPost = ({post, author, tag}) => `type ${post} implements Node {
+  id: ID!
+  uuid: String
+  title: String
+  slug: String
+  html: String
+  comment_id: String
+  plaintext: String
+  feature_image: String
+  featured: Boolean
+  created_at: Date
+  updated_at: Date
+  published_at: Date
+  custom_excerpt: String
+  codeinjection_head: String
+  codeinjection_foot: String
+  tags: [${tag}]
+  authors: [${author}]
+  primary_author: ${author}
+  primary_tag: ${tag}
+  url: String
+  page: Boolean
+  excerpt: String
+  og_image: String
+  og_title: String
+  og_description: String
+  twitter_image: String
+  twitter_title: String
+  twitter_description: String
+  meta_title: String
+  meta_description: String
+  ghostId: String
+  mobiledoc: String
+  codeinjection_styles: String
+}`
+const GhostPage = ({page, author, tag}) => `type ${page} implements Node {
+  id: ID!
+  uuid: String
+  title: String
+  slug: String
+  url: String
+  mobiledoc: String
+  html: String
+  comment_id: String
+  plaintext: String
+  feature_image: String
+  featured: Boolean
+  page: Boolean
+  meta_title: String
+  meta_description: String
+  created_at: Date
+  updated_at: Date
+  published_at: Date
+  custom_excerpt: String
+  excerpt: String
+  codeinjection_head: String
+  codeinjection_foot: String
+  codeinjection_styles: String
+  og_image: String
+  og_title: String
+  og_description: String
+  twitter_image: String
+  twitter_title: String
+  twitter_description: String
+  custom_template: String
+  primary_author: ${author}
+  primary_tag: ${tag}
+  authors: [${author}]
+  tags: [${tag}]
+  ghostId: String
+}`
+
+module.exports = {
+  GhostAuthor,
+  GhostTag,
+  GhostPost,
+  GhostPage,
+}

--- a/packages/source-ghost/ghost-schema.js
+++ b/packages/source-ghost/ghost-schema.js
@@ -103,5 +103,5 @@ module.exports = {
   GhostAuthor,
   GhostTag,
   GhostPost,
-  GhostPage,
+  GhostPage
 }

--- a/packages/source-ghost/index.js
+++ b/packages/source-ghost/index.js
@@ -1,6 +1,5 @@
 const GhostContentAPI = require('@tryghost/content-api')
 const camelCase = require('camelcase')
-const getConfig = require('../ghost-config')
 const schemaTypes = require('./ghost-schema')
 
 const TYPE_AUTHOR = 'author'
@@ -9,9 +8,19 @@ const TYPE_PAGE = 'page'
 const TYPE_TAG = 'tag'
 
 class GhostSource {
+  static defaultOptions () {
+    return {
+      baseUrl: '',
+      contentKey: '',
+      perPage: 100,
+      version: 'v2',
+      typeName: 'Ghost',
+      settingsName: null
+    }
+  }
+
   constructor (api, options) {
     this.api = api
-    options = options || getConfig()
     this.options = options
     this.restBases = { posts: {}, taxonomies: {}}
     this.typeNames = {
@@ -40,7 +49,7 @@ class GhostSource {
       await this.loadSettings(actions)
     })
 
-    api.createSchema(async ({ addSchemaTypes, addMetadata, addSchemaResolvers }) => {
+    api.createSchema(async ({ addSchemaTypes }) => {
       addSchemaTypes(schemaTypes.GhostAuthor(this.typeNames))
       addSchemaTypes(schemaTypes.GhostTag(this.typeNames))
       addSchemaTypes(schemaTypes.GhostPost(this.typeNames))

--- a/packages/source-ghost/index.js
+++ b/packages/source-ghost/index.js
@@ -55,9 +55,6 @@ class GhostSource {
       addSchemaTypes(schemaTypes.GhostPost(this.typeNames))
       addSchemaTypes(schemaTypes.GhostPage(this.typeNames))
     })
-
-    api.createPages(async () => {
-    })
   }
 
   async loadTags ({ addCollection }) {

--- a/packages/source-ghost/index.js
+++ b/packages/source-ghost/index.js
@@ -27,7 +27,7 @@ class GhostSource {
       author: this.createTypeName(TYPE_AUTHOR),
       post: this.createTypeName(TYPE_POST),
       page: this.createTypeName(TYPE_PAGE),
-      tag: this.createTypeName(TYPE_TAG),
+      tag: this.createTypeName(TYPE_TAG)
     }
 
     this.contentAPI = new GhostContentAPI({
@@ -95,8 +95,8 @@ class GhostSource {
       dateField: 'published_at'
     })
 
-    const tagTypeName = this.typeNames.tag;
-    const authorTypeName = this.typeNames.author;
+    const tagTypeName = this.typeNames.tag
+    const authorTypeName = this.typeNames.author
 
     let keepGoing = true
     let currentPage = 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,10 +1908,10 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@tryghost/content-api@^1.2.2":
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@tryghost/content-api/-/content-api-1.2.8.tgz#715c18e201982821964068d448ff0332c5f19695"
-  integrity sha512-iApR5dZbnv5ZCjZT3kyGp3kBXftRuRnrCW939clsCVJKYGdbY237C3HIy+OrC/YJpY0OaO6YKR/dCdDoJaA6Bg==
+"@tryghost/content-api@^1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@tryghost/content-api/-/content-api-1.3.4.tgz#d2869656d1a0d9a2ba2423963494547130ca20d2"
+  integrity sha512-r5h0pKX0m17ME0s5W6e3swcDDBn0AkhQKKuMwDOOSzxkUMMWEE6L7fBsIgw/uIR0UjweLiHdYsjxd0Gs9d6Ajw==
   dependencies:
     axios "0.19.0"
     ghost-ignition "^3.0.0"


### PR DESCRIPTION
Adds explicit schemas so that ghost fields on posts, pages, authors and tags that are empty can still be queried. Relates to #871.