### PR TITLE
Added remark that https is mandatory

### DIFF
--- a/packages/source-wordpress/README.md
+++ b/packages/source-wordpress/README.md
@@ -15,7 +15,7 @@ module.exports = {
     {
       use: '@gridsome/source-wordpress',
       options: {
-        baseUrl: 'WEBSITE_URL', // required
+        baseUrl: 'WEBSITE_URL', // https required
         apiBase: 'wp-json',
         typeName: 'WordPress',
         perPage: 100,


### PR DESCRIPTION
Without https, wordpress will not allow the access to the users endpoint.

I wish I knew that before... :-)