### PR TITLE
fix(source-wordpress) Update error formatting in fetch method

### DIFF
--- a/packages/source-wordpress/index.js
+++ b/packages/source-wordpress/index.js
@@ -186,14 +186,11 @@ class WordPressSource {
         throw new Error(`${code} - ${config.url}`)
       }
 
-      const { url } = response.config
-      const { status } = response.data.data
-
-      if ([401, 403].includes(status)) {
-        console.warn(`Error: Status ${status} - ${url}`)
+      if ([401, 403].includes(response.status)) {
+        console.warn(`Error: Status ${response.status} - ${config.url}`)
         return { ...response, data: fallbackData }
       } else {
-        throw new Error(`${status} - ${url}`)
+        throw new Error(`${response.status} - ${config.url}`)
       }
     }
 


### PR DESCRIPTION
Update error formatting in fetch method.

Use `response.status`, instead of trying to destructure `status` from `response.data`, as if there is an error, then data will be null - therefore `status` cannot be destructured from it.