### PR TITLE
use env variable for cpu count and removed unused model from cpus

### DIFF
--- a/gridsome/lib/utils/sysinfo.js
+++ b/gridsome/lib/utils/sysinfo.js
@@ -4,8 +4,7 @@ const cpus = os.cpus()
 
 module.exports = {
   cpus: {
-    model: cpus.length ? cpus[0].model : '',
-    logical: cpus.length,
-    physical: physical || 1
+    logical: parseInt(process.env.GRIDSOME_CPU_COUNT || cpus.length, 10),
+    physical: parseInt(process.env.GRIDSOME_CPU_COUNT || physical || 1, 10)
   }
 }


### PR DESCRIPTION
We encountered an issue on circleci regarding the cpu count. They advertise more cpus than you are allowed to use, so we got some memory errors. We solved this by using an environment variable as proposed in this pull request.