### PR TITLE
fix(pages API) Update removePage to return if no page found

### DIFF
--- a/gridsome/lib/pages/pages.js
+++ b/gridsome/lib/pages/pages.js
@@ -203,6 +203,7 @@ class Pages {
 
   removePage (id) {
     const page = this.getPage(id)
+    if (!page) return
     const route = this.getRoute(page.internal.route)
 
     if (route.internal.isDynamic) {


### PR DESCRIPTION
Added a return if no page is found, otherwise an error is thrown `Cannot read property 'internal' of undefined`, and the build breaks.

I don't know whether it should just silently return, or perhaps log a message that the page wasn't found?