### PR TITLE
fix(build): handle errors without an sub-error

### DIFF
--- a/gridsome/lib/webpack/compileAssets.js
+++ b/gridsome/lib/webpack/compileAssets.js
@@ -25,9 +25,8 @@ module.exports = async (app, defines = {}) => {
 
       if (stats.hasErrors()) {
         const errors = stats.stats
-          .map(stats => stats.compilation.errors)
-          .reduce((acc, errors) => acc.concat(errors), [])
-          .map(err => err.error)
+          .flatMap(stats => stats.compilation.errors)
+          .map(err => err.error || err)
 
         return reject(errors[0])
       }

--- a/gridsome/lib/webpack/compileAssets.js
+++ b/gridsome/lib/webpack/compileAssets.js
@@ -25,7 +25,9 @@ module.exports = async (app, defines = {}) => {
 
       if (stats.hasErrors()) {
         const errors = stats.stats
-          .flatMap(stats => stats.compilation.errors)
+          // .flatMap(stats => stats.compilation.errors) only exists in Node v11+
+          .map(stats => stats.compilation.errors)
+          .reduce((acc, errors) => acc.concat(errors), [])
           .map(err => err.error || err)
 
         return reject(errors[0])


### PR DESCRIPTION
When I added the following performance option:
```
  configureWebpack: {
    // merged with the internal config
    performance: {
      hints: "error",
      maxEntrypointSize: 1
    }
  },
```
The build failed, but the error message was not helpful:
```
(node:12752) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'stack' of undefined
```

This is because the `stats.compilation.errors` does not contain an `.error` subkey in case of a performance issue (when some assets are to big for instance).

This PR fixes this (and uses `flatMap` which looks tidier)