### PR TITLE
allow overriding NODE_ENV during build

### DIFF
--- a/gridsome/lib/build.js
+++ b/gridsome/lib/build.js
@@ -9,7 +9,7 @@ const { logAllWarnings } = require('./utils/deprecate')
 const { log, info, writeLine } = require('./utils/log')
 
 module.exports = async (context, args) => {
-  process.env.NODE_ENV = 'production'
+  process.env.NODE_ENV = process.env.NODE_ENV || 'production'
   process.env.GRIDSOME_MODE = 'static'
 
   const buildTime = hirestime()


### PR DESCRIPTION
The NODE_ENV could be set to `staging` or  `testing` during the build process. If I am ignoring something, please let me know.