### PR TITLE
Allow GLink and GImage to be used

### DIFF
--- a/gridsome/app/app.js
+++ b/gridsome/app/app.js
@@ -16,8 +16,8 @@ import Image from './components/Image'
 import ClientOnly from './components/ClientOnly'
 
 Vue.mixin(graphqlMixin)
-Vue.component('g-link', Link)
-Vue.component('g-image', Image)
+Vue.component('GLink', Link)
+Vue.component('GImage', Image)
 Vue.component('ClientOnly', ClientOnly)
 
 Vue.prototype.$url = url

--- a/gridsome/lib/webpack/modules/assets.js
+++ b/gridsome/lib/webpack/modules/assets.js
@@ -1,21 +1,21 @@
 const isUrl = require('is-url')
 const camelcase = require('camelcase')
 const isRelative = require('is-relative')
-const { isMailtoLink, isTelLink } = require('../../utils')
+const {isMailtoLink, isTelLink} = require('../../utils')
 
 module.exports = () => ({
-  postTransformNode (node) {
-    if (node.tag === 'g-link') {
+  postTransformNode(node) {
+    if (['GLink', 'g-link'].includes(node.tag)) {
       transformNodeAttr(node, 'to')
     }
 
-    if (node.tag === 'g-image') {
+    if (['GImage', 'g-image'].includes(node.tag)) {
       transformNodeAttr(node, 'src')
     }
   }
 })
 
-function transformNodeAttr (node, attrName) {
+function transformNodeAttr(node, attrName) {
   if (!Array.isArray(node.attrs)) return
 
   for (const attr of node.attrs) {
@@ -28,7 +28,7 @@ function transformNodeAttr (node, attrName) {
   }
 }
 
-function transformAttrValue (node, attr) {
+function transformAttrValue(node, attr) {
   const value = extractValue(attr.value)
   let result = attr.value
 
@@ -40,19 +40,19 @@ function transformAttrValue (node, attr) {
   return result
 }
 
-function isStatic (value) {
+function isStatic(value) {
   return /^"[^"]+"$/.test(value)
 }
 
-function extractValue (value) {
+function extractValue(value) {
   return value.substr(1, value.length - 2)
 }
 
-function createOptionsQuery (attrs) {
+function createOptionsQuery(attrs) {
   return attrs
     .filter(attr => attr.name !== 'src')
     .filter(attr => isStatic(attr.value))
-    .map(attr => ({ name: camelcase(attr.name), value: extractValue(attr.value) }))
+    .map(attr => ({name: camelcase(attr.name), value: extractValue(attr.value)}))
     .map(attr => `${attr.name}=${encodeURIComponent(attr.value)}`)
     .join('&')
 }


### PR DESCRIPTION
This will allow users to use `GLink` as well as `g-link` and `GImage` along with `g-image`.

Fixes #983.