### PR TITLE
Check that srcset is array before joining, else expect it to be string

### DIFF
--- a/gridsome/app/components/Image.js
+++ b/gridsome/app/components/Image.js
@@ -42,7 +42,7 @@ export default {
         attrs.width = size.width
 
         if (isLazy) attrs['data-src'] = src
-        if (srcset.length) attrs[`${isLazy ? 'data-' : ''}srcset`] = srcset.join(', ')
+        if (srcset.length) attrs[`${isLazy ? 'data-' : ''}srcset`] = Array.isArray(srcset) ? srcset.join(', ') : srcset
         if (sizes) attrs[`${isLazy ? 'data-' : ''}sizes`] = sizes
 
         if (isLazy) {


### PR DESCRIPTION
This is to fix an issue where srcset is not generated by Gridsome but does exist on the object given to g-image.