### PR TITLE
Add error handling for the build schema from source step

### DIFF
--- a/gridsome/lib/graphql/createFieldDefinitions.js
+++ b/gridsome/lib/graphql/createFieldDefinitions.js
@@ -9,7 +9,8 @@ const {
   isEmpty,
   isNumber,
   isInteger,
-  isPlainObject
+  isPlainObject,
+  isArrayLike
 } = require('lodash')
 
 module.exports = function createFieldDefinitions (nodes, options = {}) {
@@ -24,6 +25,9 @@ module.exports = function createFieldDefinitions (nodes, options = {}) {
 }
 
 function resolveValues (obj, currentObj = {}, options = {}, path = []) {
+  if (isArrayLike(currentObj)) {
+    throw new Error(`Cannot resolve field for: ${obj} and ${currentObj}, please check to make sure your data sources have compatible shapes`)
+  }
   const res = { ...currentObj }
 
   for (const key in obj) {


### PR DESCRIPTION
Closes #991 

Added a conditional in `lib/graphql/createFieldDefinitions` where if the `currentObj` input is an iterable, then the function throws. The Schema building step will crash either ways because it tries to access a nested value that doesn't exist on a spreaded iterator(array or string), and the additional error message is meant to help with troubleshooting.

Also wasn't sure if I should add tests or not, but I can do that if need be.