### PR TITLE
Prefix route with pathPrefix when hard reloading view

### DIFF
--- a/gridsome/app/entry.client.js
+++ b/gridsome/app/entry.client.js
@@ -28,7 +28,8 @@ if (process.env.NODE_ENV === 'production') {
       .catch(err => {
         // reload page if a component failed to load
         if (err.request && to.path !== window.location.pathname) {
-          window.location.assign(to.fullPath)
+          const fullPathWithPrefix = (config.pathPrefix ?? '') + to.fullPath
+          window.location.assign(fullPathWithPrefix)
         } else {
           next(err)
         }

--- a/gridsome/app/graphql/guard.js
+++ b/gridsome/app/graphql/guard.js
@@ -1,4 +1,5 @@
 import fetch from '../fetch'
+import config from '~/.temp/config'
 import { getResults, setResults, formatError } from './shared'
 
 export default (to, from, next) => {
@@ -32,7 +33,8 @@ export default (to, from, next) => {
         console.error(err)
         next({ name: '*', params: { 0: to.path } })
       } else if (err.code === 'INVALID_HASH' && to.path !== window.location.pathname) {
-        window.location.assign(to.fullPath)
+        const fullPathWithPrefix = (config.pathPrefix ?? '') + to.fullPath
+        window.location.assign(fullPathWithPrefix)
       } else {
         formatError(err, to)
         next(err)


### PR DESCRIPTION
Fixes #1043 

This prefixes the route with the configured `pathPrefix` when attempting to do a full route reload, as client side routes aren't prefixed, but the server will need them.

I'm not sure how to test locally so I'm not sure if the `guard.js` file changes are ok, I just included the config in the same way it was already included in the `entry.client.js` file.