### PR TITLE
feat(source-airtable): add option for linked tables

### DIFF
--- a/packages/source-airtable/README.md
+++ b/packages/source-airtable/README.md
@@ -15,10 +15,26 @@ module.exports = {
       use: '@gridsome/source-airtable',
       options: {
         apiKey: 'YOUR_API_KEY', // required
-        baseId: 'YOUR_BASE_ID', // required
+        base: 'YOUR_BASE_ID', // required
+        tables: [
+            {
+                name: 'YOUR_TABLE_NAME', // required
+                typeName: 'YOUR_TYPE_NAME', // required
+                select: {}, // optional,
+                links: [ // optional
+                    {
+                        fieldName: 'Case Sensitive Field Name',
+                        typeName: 'TYPE_NAME_FROM_LINKED_TABLE',
+                        linkToFirst: false // optional
+                    }
+                ]
+            },
+            {
+                name: 'YOUR_LINKED_TABLE_NAME', // required
+                typeName: 'YOUR_LINKED_TYPE_NAME', // required
+            } 
+        ],
         tableName: 'YOUR_TABLE_NAME', // required
-        typeName: 'YOUR_TYPE_NAME', // required
-        select: {}, // optional
       },
     },
   ],
@@ -31,7 +47,12 @@ module.exports = {
 ## Options
 
 1. `apiKey`: This can be found when logged in to airtable.com, under "ACCOUNT > API"
-1. `baseId`: This can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible in the url: https://airtable.com/{YOUR_BASE_ID}/api/docs#curl/introduction
-1. `tableName`: This is the full name of your chosen workspace table, for example "Furniture" is the first and main table in the pre-defined workspace named "Product Catalog & Orders"
-1. `typeName`: Your chosen type name. The type name "Product" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"
-1. `select`: Your select options. These can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible under the _List records_ of your table
+2. `base`: This can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible in the url: https://airtable.com/{YOUR_BASE_ID}/api/docs#curl/introduction
+3. `tables`: This is where you configure one or more tables that should be loaded as a data source 
+    1. `name`:  This is the full name of your chosen workspace table, for example "Furniture" is the first and main table in the pre-defined workspace named "Product Catalog & Orders"
+    2. `typeName`: Your chosen type name. The type name "Product" is an example of an fitting route for the pre-defined airtable workspace named "Product Catalog & Orders"
+    3. `select`: Your select options. These can be found by going to https://airtable.com/api, clicking on your workspace, and will be visible under the _List records_ of your table
+    4. `links`: When links to another record are set in airtable, they need to be also mapped so we can return them as a sub-object
+        1. `fieldName`: This is the case sensitive full name of the field that has been set as a "Link to another record type" 
+        2. `typeName`: This is the type name of the linked table that has been added to the "tables" config
+        3. `linkToFirst`: Airtable always returns linked records as an array of records, but there is sometimes a case when you have only one record linked. This is the convenient option that will extract the first record from array and return an object. It emulates the "one to one" relation from RDBMS

--- a/packages/source-airtable/index.js
+++ b/packages/source-airtable/index.js
@@ -1,28 +1,80 @@
 const Airtable = require('airtable')
+// eslint-disable-next-line node/no-unpublished-require
+const { deprecate } = require('../../gridsome/lib/utils/deprecate')
 
-module.exports = function (api, options) {
-  const base = new Airtable({ apiKey: options.apiKey }).base(options.baseId)
+class AirtableSource {
+  constructor (api, options) {
+    // renamed "baseId" config to "base"
+    options.base = options.base || options.baseId
+    this.base = new Airtable({ apiKey: options.apiKey }).base(options.base)
 
-  api.loadSource(async actions => {
-    const addCollection = actions.addCollection || actions.addContentType
-
-    const collection = addCollection({
-      camelCasedFieldNames: true,
-      typeName: options.typeName,
-      route: options.route
+    api.loadSource(async ({ addCollection, store }) => {
+      this.store = store
+      this.addCollection = addCollection
+      // to avoid breaking changes when someone is using old config options
+      // convert to new format and show deprecation warning
+      if (!!options.tableName && !options.tables) {
+        options.tables = [
+          {
+            name: options.tableName,
+            typeName: options.typeName
+          }
+        ]
+        deprecate(`@gridsome/airtable-source: "tableName" option in config will be deprecated. 
+          You should switch to "tables" array config instead`)
+      }
+      await this.loadRecordsToCollections(options)
     })
+  }
 
-    await base(options.tableName)
-      .select(options.select || {})
-      .eachPage((records, fetchNextPage) => {
-        records.forEach((record) => {
-          const item = record._rawJson
-          collection.addNode({
-            id: item.id,
-            ...item.fields
-          })
-        })
-        fetchNextPage()
+  loadRecordsToCollections = async function (options) {
+    for (const table of options.tables) {
+      const collection = this.addCollection({
+        camelCasedFieldNames: true,
+        typeName: table.typeName,
+        route: table.route
       })
-  })
+      await this.base(table.name)
+        .select(table.select || {})
+        .eachPage((records, fetchNextPage) => {
+          records.forEach((record) => {
+            this.addRecordToNode(record._rawJson, table, collection)
+          })
+          fetchNextPage()
+        })
+    }
+  }
+
+  addRecordToNode = function (item, table, collection) {
+    if (table.links && table.links.length) {
+      item = this.addLinkedRecords(item, table)
+    }
+
+    collection.addNode({
+      id: item.id,
+      ...item.fields
+    })
+  }
+
+  addLinkedRecords = function (item, table) {
+    table.links.forEach(link => {
+      if (!item.fields[link.fieldName]) {
+        return item
+      }
+      // when relation is set to "linkToFirst"
+      // we just want the first id in the array
+      // and return an object
+      if (link.linkToFirst === true) {
+        const id = item.fields[link.fieldName][0]
+        item.fields[link.fieldName] = this.store.createReference(link.typeName, id)
+        return item
+      }
+      // create reference for each id in the array that Airtable api returns
+      item.fields[link.fieldName] = item.fields[link.fieldName].map(id => {
+        return this.store.createReference(link.typeName, id)
+      })
+    })
+    return item
+  }
 }
+module.exports = AirtableSource

--- a/packages/source-airtable/index.js
+++ b/packages/source-airtable/index.js
@@ -1,5 +1,4 @@
 const Airtable = require('airtable')
-// eslint-disable-next-line node/no-unpublished-require
 const { deprecate } = require('gridsome/lib/utils/deprecate')
 
 class AirtableSource {

--- a/packages/source-airtable/index.js
+++ b/packages/source-airtable/index.js
@@ -1,6 +1,6 @@
 const Airtable = require('airtable')
 // eslint-disable-next-line node/no-unpublished-require
-const { deprecate } = require('../../gridsome/lib/utils/deprecate')
+const { deprecate } = require('gridsome/lib/utils/deprecate')
 
 class AirtableSource {
   constructor (api, options) {

--- a/packages/source-airtable/package.json
+++ b/packages/source-airtable/package.json
@@ -14,6 +14,9 @@
   "dependencies": {
     "airtable": "^0.7.2"
   },
+  "peerDependencies": {
+    "gridsome": "0.x"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Updated configuration to accept multiple tables as a source. Introduced new syntax with "tables" array but tried not to introduce breaking changes. It would just show deprecation warning when the old syntax is used.

Added option for linking tables: In Airtable when you set a field to link to another table api just returns  array od ids. Now it maps the actual objects to the ids and returns as a nested resource.

Also added syntax when you link to only one record in the table to conveniently return a first result as an object and not as an array. Inspired by "one to one" convention from relational databases.

I'm already using this implementation on my gridsome project, but I would like to hear comments if I did something wrong or unconventional, and if there are maybe some performance issues with this solution.

Also would like to hear comments about the configuration syntax and naming, I was a little inspired by gatsby source plugin, but I modified it to better fit my personal mental model.