### PR TITLE
Add configuration option for entries limit

### DIFF
--- a/packages/source-contentful/index.js
+++ b/packages/source-contentful/index.js
@@ -10,6 +10,7 @@ class ContentfulSource {
       environment: 'master',
       host: 'cdn.contentful.com',
       typeName: 'Contentful',
+      entiresBatchSize: 1000,
       richText: {},
       routes: {}
     }
@@ -70,7 +71,7 @@ class ContentfulSource {
   }
 
   async getEntries (actions) {
-    const entries = await this.fetch('getEntries')
+    const entries = await this.fetch('getEntries', this.options.entiresBatchSize)
 
     for (const entry of entries) {
       const typeId = entry.sys.contentType.sys.id


### PR DESCRIPTION
This solves the issue of Contentful's API sending a 400 status code due to a technical limitation defined in their API.  Response Size can not be greater than 7MB.  https://www.contentful.com/developers/docs/technical-limits/ 