### PR TITLE
Add suffix test to allow for trailing slash on Pager component

### DIFF
--- a/gridsome/app/utils/helpers.js
+++ b/gridsome/app/utils/helpers.js
@@ -21,10 +21,11 @@ export function url (string = '/') {
 export function stripPageParam (route) {
   const { path, params: { page }} = route
   const normalizedPath = unslashEnd(path)
+  const suffix = /\/$/.test(path) ? '/' : ''
 
   return page && /^\d+$/.test(page) && /\/\d+$/.test(normalizedPath)
-    ? normalizedPath.split('/').slice(0, -1).join('/') || '/'
-    : normalizedPath || '/'
+    ? `${normalizedPath.split('/').slice(0, -1).join('/')}${suffix}` || '/'
+    : `${normalizedPath}${suffix}` || '/'
 }
 
 export function stripPathPrefix (string) {


### PR DESCRIPTION
This allows for Pager links to have a trailing slash or not have trailing slash depending on vue route