### PR TITLE
transformer-remark: Populate excerpt with text

### DIFF
--- a/packages/transformer-remark/index.js
+++ b/packages/transformer-remark/index.js
@@ -122,36 +122,30 @@ class RemarkTransformer {
         args: {
           length: {
             type: GraphQLInt,
-            description: 'Characters',
+            description: 'Maximum length (characters)',
             defaultValue: 200
-          },
-          ellipses: {
-            type: GraphQLString,
-            description: 'String to add to end of excerpt',
-            defaultValue: '…'
           }
         },
-        resolve: async (node, { length, ellipses }) => {
+        resolve: async (node, { length }) => {
           const key = cacheKey(node, 'excerpt')
-          let cached = cache.get(key)
+          let excerpt = node.excerpt || cache.get(key)
 
-          if (!cached) {
+          if (!excerpt) {
             const html = await this._nodeToHTML(node)
             // Remove html tags, then newlines.
-            const text = sanitizeHTML(html, {
+            excerpt = sanitizeHTML(html, {
               allowedAttributes: {},
               allowedTags: []
             }).replace(/\r?\n|\r/g, ' ')
 
-            if (text.length <= length) {
-              cached = text
-            } else {
-              cached = text.substr(0, text.lastIndexOf(' ', length)) + ellipses
+            if (excerpt.length > length && length) {
+              excerpt = excerpt.substr(0, excerpt.lastIndexOf(' ', length - 1))
             }
-            cache.set(key, cached)
+
+            cache.set(key, excerpt)
           }
 
-          return cached
+          return excerpt
         }
       }
     }

--- a/packages/transformer-remark/index.js
+++ b/packages/transformer-remark/index.js
@@ -122,7 +122,7 @@ class RemarkTransformer {
         args: {
           length: {
             type: GraphQLInt,
-            description: 'Maximum length (characters)',
+            description: 'Maximum length of generated excerpt (characters)',
             defaultValue: 200
           }
         },

--- a/packages/transformer-remark/index.js
+++ b/packages/transformer-remark/index.js
@@ -116,6 +116,43 @@ class RemarkTransformer {
 
           return cached
         }
+      },
+      excerpt: {
+        type: GraphQLString,
+        args: {
+          length: {
+            type: GraphQLInt,
+            description: 'Characters',
+            defaultValue: 200
+          },
+          ellipses: {
+            type: GraphQLString,
+            description: 'String to add to end of excerpt',
+            defaultValue: '…'
+          }
+        },
+        resolve: async (node, { length, ellipses }) => {
+          const key = cacheKey(node, 'excerpt')
+          let cached = cache.get(key)
+
+          if (!cached) {
+            const html = await this._nodeToHTML(node)
+            // Remove html tags, then newlines.
+            const text = sanitizeHTML(html, {
+              allowedAttributes: {},
+              allowedTags: []
+            }).replace(/\r?\n|\r/g, ' ')
+
+            if (text.length <= length) {
+              cached = text
+            } else {
+              cached = text.substr(0, text.lastIndexOf(' ', length)) + ellipses
+            }
+            cache.set(key, cached)
+          }
+
+          return cached
+        }
       }
     }
   }


### PR DESCRIPTION
As mentioned in #237, the `excerpt` field is empty by default. Configuration can be passed to `gray-matter` to populate this field (#284), however `gray-matter` excerpts are not parsed when extracted this way.

This PR addresses this as follows:
- If the user has already got a gray-matter config to populate `excerpt`, it does not overwrite this value.
- If `excerpt` is empty, it populates it with:
  - Raw text, as taken from `sanitizeHTML()`.
  - Newlines are removed and replaced with spaces.
  - The text is limited to at most `length` characters, but will not snip mid-word.
- `excerpt` is added to the schema, including a `length` argument, with a default of 200 characters.
