### PR TITLE
feat(ghost): Add reading_time for ghost posts

### DIFF
--- a/packages/source-ghost/ghost-schema.js
+++ b/packages/source-ghost/ghost-schema.js
@@ -50,6 +50,7 @@ const GhostPost = ({ post, author, tag }) => `type ${post} implements Node {
   url: String
   page: Boolean
   excerpt: String
+  reading_time: Int
   og_image: String
   og_title: String
   og_description: String


### PR DESCRIPTION
Simple change, just adds the reading_time parameter ([see ghost api docs](https://ghost.org/docs/api/v3/content/#posts))