### PR TITLE
Added support for functional components to make use of gql static-query

### DIFF
--- a/gridsome/lib/plugins/vue-components/lib/loaders/static-query.js
+++ b/gridsome/lib/plugins/vue-components/lib/loaders/static-query.js
@@ -73,9 +73,17 @@ module.exports = async function (source, map) {
 
       options.__staticData = Vue.observable({ data })
 
-      options.computed = computed({
-        $static: () => options.__staticData.data
-      }, options.computed)
+      if (options.functional) {
+        options.__render = options.render
+        options.render = function(h, ctx) {
+          ctx.data.$static = options.__staticData.data
+          return options.__render(h, ctx)
+        }
+      } else {
+        options.computed = computed({
+          $static: () => options.__staticData.data
+        }, options.computed)
+      }
     }
   `
 


### PR DESCRIPTION
Exposes `$static` within the render function on the `context` argument at `context.data.$static`

Since functional components don't have state they pair nicely with static queries.