### PR TITLE
Add Support for Strapi Source to fetch Single Types

### DIFF
--- a/packages/source-strapi/README.md
+++ b/packages/source-strapi/README.md
@@ -18,6 +18,7 @@ export default {
         apiURL: 'http://localhost:1337',
         queryLimit: 1000, // Defaults to 100
         contentTypes: ['article', 'user'],
+        singleTypes: ['impressum'],
         // Possibility to login with a Strapi user,
         // when content types are not publicly available (optional).
         loginData: {

--- a/packages/source-strapi/helpers/query.js
+++ b/packages/source-strapi/helpers/query.js
@@ -1,14 +1,13 @@
 const axios = require('axios')
 const pluralize = require('pluralize')
 
-module.exports = async ({ apiURL, resourceName, jwtToken, queryLimit, isSingleType}) => {
+module.exports = async ({ apiURL, resourceName, jwtToken, queryLimit, isSingleType }) => {
   let resource
-  if(isSingleType) {
+  if (isSingleType) {
     resource = resourceName
   } else {
     resource = pluralize(resourceName)
   }
-  
 
   // Define API endpoint.
   const apiEndpoint = `${apiURL}/${resource}?_limit=${queryLimit}`


### PR DESCRIPTION
The Strapi CMS features Collection Types as well as single Types.

Those Commits enable the plugin to fetch the Single Types as well.