### PR TITLE
fix(sass-loader): improve default options (#750)

### DIFF
--- a/gridsome/lib/app/loadConfig.js
+++ b/gridsome/lib/app/loadConfig.js
@@ -34,7 +34,9 @@ module.exports = (context, options = {}) => {
     split: false,
     loaderOptions: {
       sass: {
-        indentedSyntax: true
+        sassOptions: {
+          indentedSyntax: true
+        }
       },
       stylus: {
         preferPathResolver: 'webpack'


### PR DESCRIPTION
Change to be compatible with sass-loader@8 as reported in #750.

The option `indentedSyntax` of the sass-loader is now defined under `sassOptions`.
This pull request modifies the default definition of gridsome to be compatible with the sass-loader configuration.

A description of the sassOptions of the sass-loader is given below:
webpack-contrib/sass-loader: Compiles Sass to CSS
https://github.com/webpack-contrib/sass-loader#sassoptions.