### PR TITLE
fix(app): add extra debugging output on hash mismatch failure

### DIFF
--- a/gridsome/app/fetch.js
+++ b/gridsome/app/fetch.js
@@ -69,7 +69,10 @@ export default (route, options = {}) => {
 
     return isLoaded[jsonPath]
       .then(res => {
-        if (res.hash !== hashMeta) reject(createError('Hash did not match.', 'INVALID_HASH'))
+        if (res.hash !== hashMeta) reject(
+          createError(`Hash did not match: json=${res.hash}, document=${hashMeta}`,
+                      'INVALID_HASH')
+          )
         else resolve(res)
       })
       .catch(reject)


### PR DESCRIPTION
Several clients are reporting non-deterministic app crashes caused by a mismatch in hashes (#1032). This adds additional context to the error to make it easier to diagnose the root cause.