### PR TITLE
Add a vue-gtag based rewrite of @gridsome/plugin-google-analytics

### DIFF
--- a/packages/plugin-gtag/CHANGELOG.md
+++ b/packages/plugin-gtag/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/plugin-gtag/README.md
+++ b/packages/plugin-gtag/README.md
@@ -1,0 +1,24 @@
+# @gridsome/plugin-gtag
+
+> Global Site Tag (gtag) plugin for Gridsome
+
+See [vue-gtag](https://github.com/MatteoGabriele/vue-gtag) for available options.
+
+## Install
+- `yarn add @gridsome/plugin-gtag`
+- `npm install @gridsome/plugin-gtag`
+
+## Usage
+
+```js
+module.exports = {
+  plugins: [
+    {
+      use: '@gridsome/plugin-gtag',
+      options: {
+        config: { id: "UA-XXXXXXXXX-X" },
+      }
+    }
+  ]
+}
+```

--- a/packages/plugin-gtag/gridsome.client.js
+++ b/packages/plugin-gtag/gridsome.client.js
@@ -1,0 +1,7 @@
+import VueGtag from "vue-gtag"
+
+export default function (Vue, options, { isClient, router }) {
+  if (isClient) {
+    Vue.use(VueGtag, options, router)
+  }
+}

--- a/packages/plugin-gtag/gridsome.server.js
+++ b/packages/plugin-gtag/gridsome.server.js
@@ -1,0 +1,5 @@
+module.exports = (api, options) => {
+  // If enabled is not overridden from the plugin configuration, set a default.
+  options.enabled = options.enabled ?? process.env.NODE_ENV === 'production'
+  api.setClientOptions(options)
+}

--- a/packages/plugin-gtag/package.json
+++ b/packages/plugin-gtag/package.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.1.0",
+  "name": "gridsome-plugin-gtag",
+  "description": "Global Site Tag (gtag) plugin for Gridsome",
+  "homepage": "https://github.com/gridsome/gridsome/tree/master/packages/plugin-gtag#readme",
+  "repository": "https://github.com/gridsome/gridsome/tree/master/packages/plugin-gtag",
+  "main": "gridsome.client.js",
+  "license": "MIT",
+  "files": [
+    "gridsome.client.js"
+  ],
+  "keywords": [
+    "gridsome",
+    "gridsome-plugin",
+    "analytics"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "vue-gtag": "^1.6.2"
+  },
+  "engines": {
+    "node": ">=8"
+  }
+}


### PR DESCRIPTION
As discussed in https://github.com/gridsome/gridsome/issues/816, there is demand for a Google global site tag (gtag) implementation in Gridsome. The current @gridsome/plugin-google-analytics plugin is based on [vue-analytics](https://github.com/MatteoGabriele/vue-analytics), which is being deprecated in favor of [vue-gtag](https://github.com/MatteoGabriele/vue-gtag). 

This @gridsome/plugin-gtag plugin is a rewrite of @gridsome/plugin-google-analytics, based on vue-gtag. I could publish it as a separate package, but given the situation it probably makes sense to ship it as part of @gridsome (hence this PR).

In the long term I think this could replace @gridsome/plugin-google-analytics, but of course it would require a strategy to migrate current implementations to the new plugin.