### PR TITLE
Add Native Image Lazy Loading

### DIFF
--- a/gridsome/app/components/Image.js
+++ b/gridsome/app/components/Image.js
@@ -28,6 +28,7 @@ export default {
 
     switch (typeof props.src) {
       case 'string':
+        attrs.isLazy = !isImmediate
         attrs.src = props.src
 
         break
@@ -84,6 +85,7 @@ export default {
         domProps: {
           innerHTML: `` +
             `<img src="${props.src.src}" class="${stringifyClass(noscriptClassNames)}"` +
+            (attrs.isLazy ? ` loading="lazy"` : '') +
             (attrs.width ? ` width="${attrs.width}"`: '') +
             (attrs.alt ? ` alt="${attrs.alt}"` : '') +
             `>`


### PR DESCRIPTION
Adds native browser lazy loading.

I have to reference some images placed in the static folder, so I can add paths to them in meta tags using vue-meta (Would love to know if there was a better way around this). Lazy loading doesn't seem to work for these images. Using native browser lazy loading should work.