### PR TITLE
fix (Plugin API Hooks) - Promises

### DIFF
--- a/gridsome/lib/app/PluginAPI.js
+++ b/gridsome/lib/app/PluginAPI.js
@@ -81,11 +81,11 @@ class PluginAPI {
   //
 
   onInit (fn) {
-    this._app.hooks.beforeBootstrap.tapAsync(this._entry.name || 'OnInit', fn)
+    this._app.hooks.beforeBootstrap.tapPromise(this._entry.name || 'OnInit', fn)
   }
 
   onBootstrap (fn) {
-    this._app.hooks.bootstrap.tapAsync(this._entry.name || 'OnBootstrap', fn)
+    this._app.hooks.bootstrap.tapPromise(this._entry.name || 'OnBootstrap', fn)
   }
 
   onCreateNode (fn) {


### PR DESCRIPTION
Update to use tapPromise instead of tapAsync.

I could only get the `onBootstrap` hook to work when I made this change, and I found it more helpful to use the promise style hooks. However, I can change the hook code to properly pass the async callback function  if you think it should be kept as `tapAsync`.
