### PR TITLE
tests: add new helper and increase coverage

### DIFF
--- a/packages/cli/__tests__/create.spec.js
+++ b/packages/cli/__tests__/create.spec.js
@@ -1,0 +1,20 @@
+const fs = require('fs')
+
+const runCLI = require('./utils/helpers')
+
+const genPath = `${__dirname}/my-project`
+
+beforeEach(() => {
+  fs.mkdirSync(genPath)
+  fs.writeFileSync(`${genPath}/index.js`, '// Test')
+})
+
+afterEach(() => {
+  fs.rmdirSync(genPath, { recursive: true })
+})
+
+test('warns if a directory with the same name exists in path', async () => {
+  const { stdout } = await runCLI(['create', 'my-project'], __dirname)
+
+  expect(stdout).toBe(`Can't create my-project because there's already a non-empty directory my-project existing in path.`)
+})

--- a/packages/cli/__tests__/gridsome.spec.js
+++ b/packages/cli/__tests__/gridsome.spec.js
@@ -1,29 +1,28 @@
 const path = require('path')
-const execa = require('execa')
-const cli = require.resolve('../bin/gridsome')
+
+const runCLI = require('./utils/helpers')
 
 test('show @gridsome/cli version', async () => {
-  const { stdout } = await execa(cli, ['-v'])
+  const { stdout } = await runCLI(['-v'])
 
   expect(stdout).toMatch(/@gridsome\/cli v(\d+\.?){3}/)
 })
 
 test('show local gridsome version', async () => {
-  const { stdout } = await execa(cli, ['-v'], {
-    cwd: path.join(__dirname, '__fixtures__', 'project')
-  })
+  const testPath = path.join(__dirname, '__fixtures__', 'project')
+  const { stdout } = await runCLI(['-v'], testPath)
 
   expect(stdout).toMatch(/gridsome v(\d+\.?){3}/)
 })
 
 test('warn about unknown command', async () => {
-  const { stdout } = await execa(cli, ['asdf'])
+  const { stdout } = await runCLI(['asdf'])
 
   expect(stdout).toMatch('Unknown command asdf')
 })
 
 test('suggest matching command', async () => {
-  const { stdout } = await execa(cli, ['creaet'])
+  const { stdout } = await runCLI(['creaet'])
 
   expect(stdout).toContain('Did you mean create?')
 })

--- a/packages/cli/__tests__/utils/helpers.js
+++ b/packages/cli/__tests__/utils/helpers.js
@@ -1,0 +1,12 @@
+const execa = require('execa')
+
+const CLI_PATH = require.resolve('../../bin/gridsome')
+
+const runCLI = (args, dir = process.cwd()) => {
+  const options = {
+    cwd: dir
+  }
+  return execa(CLI_PATH, args, options)
+}
+
+module.exports = runCLI


### PR DESCRIPTION
- Added new helper method to be consumed across the entire test suite.
- Test case to ensure `create` command shows up an appropriate warning if a directory with the same name (which isn't empty) already exists in path.