### PR TITLE
added demo runner on top of runme.io

### DIFF
--- a/.runme/Dockerfile
+++ b/.runme/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:14.0.0
+WORKDIR /app
+RUN npm install --global @gridsome/cli http-server
+RUN gridsome create my-gridsome-site && \
+    cd my-gridsome-site && \
+    gridsome build
+WORKDIR /app/my-gridsome-site
+ENTRYPOINT http-server ./dist

--- a/.runme/config.yaml
+++ b/.runme/config.yaml
@@ -1,0 +1,10 @@
+version: 1.0
+publish: app
+services:
+  app:
+    build:
+      type: dockerfile
+      config: ./.runme/Dockerfile
+    ports:
+      - container: 8080
+        public: 80

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Gridsome sites are usually not connected to any database and can be hosted entir
 1. Create `.vue` components in the `./src/pages` directory to create pages
 2. Use `gridsome build` to generate static files in a `./dist` folder
 
+## Demo
+Small demo - [![Runme](https://runme.io/static/button.svg)](https://runme.io/run?app_id=da856b58-d204-409d-9746-0dd6277da1fd)
+
 ### Learn more...
 
 - [How it works](https://gridsome.org/docs/how-it-works/)


### PR DESCRIPTION
This PR adds Runme button-label [![Runme](https://runme.io/static/button.svg)](https://runme.io/run?app_id=f7ecbdd0-f4fa-4f54-9a03-ca3ba3f43b15) to run the project from the latest commit with one click.

**How it works:**
1. Runme clones the repository and builds a docker image for latest commit;
2. deploys docker image to k8s cluster;
3. creates domain with SSL certificate;
4. shows web application;
5. destroys app instance after 10 minutes.

You can find detailed information on how this works [here](https://runme.io/how-it-works). The small demo you can find [here](https://www.youtube.com/channel/UCEysV237wo321JatUTC6Rlg).

**Why do you need this?**
- Runme is perfect solution to demonstrate current state of code/repository, anybody can just click the button and see the state;
- Runme totally free, we love open source projects and want to support them;
- Runme has only one limit: you can run one commit no more than once every 5 minutes;