### PR TITLE
fix: File assets not properly resolved in dev mode

### DIFF
--- a/gridsome/lib/app/queue/AssetsQueue.js
+++ b/gridsome/lib/app/queue/AssetsQueue.js
@@ -41,6 +41,8 @@ class AssetsQueue {
 
     if (isDev && asset.cacheKey) {
       this.index.set(asset.cacheKey, entry)
+    } else if (!asset.cacheKey && asset.relPath) {
+      this.index.set(asset.relPath, entry)
     }
 
     return entry

--- a/gridsome/lib/app/queue/FileProcessQueue.js
+++ b/gridsome/lib/app/queue/FileProcessQueue.js
@@ -59,7 +59,8 @@ class FileProcessQueue {
 
     return {
       src: encodeURI(src),
-      destPath
+      destPath,
+      relPath
     }
   }
 }

--- a/gridsome/lib/server/middlewares/assets.js
+++ b/gridsome/lib/server/middlewares/assets.js
@@ -23,7 +23,7 @@ module.exports = ({ context, config, assets }) => {
       return decodeURIComponent(value)
     })
 
-    const asset = assets.get(key)
+    const asset = assets.get(key) || assets.get(relPath)
 
     if (!asset) return res.sendStatus(404)
 


### PR DESCRIPTION
Let's look at this example, a simple collection with a file linked to it:

gridsome.server.js:
```js
module.exports = function(api) {
  api.loadSource(actions => {
    const posts = actions.addCollection({
      typeName: 'Posts'
    })

    // absolute path requried for process.GRIDSOME.assets.add()
    const audioFile = path.join(__dirname, 'src/assets/test.mp3');

    posts.addNode({
      title: 'Test',
      audio: audioFile
    })

    process.GRIDSOME.assets.add(audioFile)
  })
}
```

Posts template:
```vue
<template>
  <div>
    <!-- $page.posts.audio is of GraphQL type "File" -->
    <audio :src="$page.posts.audio.src" />
  </div>
</template>

<page-query>
query ($id: ID!) {
  posts(id: $id) {
    audio
  }
}
</page-query>
```

Previously, this worked flawlessly when building for production, but the file path during development mode resulted in a 404.