### PR TITLE
Audio/video playback issues in Chrome

### DIFF
--- a/gridsome/lib/server/middlewares/assets.js
+++ b/gridsome/lib/server/middlewares/assets.js
@@ -36,8 +36,9 @@ module.exports = ({ context, config, assets }) => {
         res.header('Expires', '-1')
       }
 
+      res.header('Accept-Ranges', 'bytes')
       res.contentType(ext)
-      res.end(buffer, 'binary')
+      res.end(buffer)
     }
 
     try {


### PR DESCRIPTION
When using `gridsome develop`, assets like audio and video files are sent without the `Accept-Ranges` header. In Chrome, this means you can't set `currentTime` of an `<audio>` element (it will reset to `0`, see this [StackOverflow thread](https://stackoverflow.com/questions/37044064/html-audio-cant-set-currenttime)).

The second paramter of `res.end` can be omitted, as it will only be used when the first parameter is a string (see [`response.write`](https://nodejs.org/api/http.html#http_response_write_chunk_encoding_callback)).