### PR TITLE
Sitemap plugin lastmod option

### DIFF
--- a/packages/plugin-sitemap/README.md
+++ b/packages/plugin-sitemap/README.md
@@ -21,11 +21,13 @@ module.exports = {
         config: {
           '/articles/*': {
             changefreq: 'weekly',
-            priority: 0.5
+            priority: 0.5,
+            lastmod: '2020-02-19',
           },
           '/about': {
             changefreq: 'monthly',
-            priority: 0.7
+            priority: 0.7,
+            lastmod: '2020-05-12',
           }
         }
       }
@@ -53,11 +55,13 @@ Set custom config for specific URLs.
 config: {
   '/articles/*': {
     changefreq: 'weekly',
-    priority: 0.5
+    priority: 0.5,
+    lastmod: '2020-02-19',
   },
   '/about': {
     changefreq: 'monthly',
-    priority: 0.7
+    priority: 0.7,
+    lastmod: '2020-05-12',
   }
 }
 ```

--- a/packages/plugin-sitemap/index.js
+++ b/packages/plugin-sitemap/index.js
@@ -24,6 +24,11 @@ module.exports = function (api, options) {
     const pathPrefix = config.pathPrefix !== '/' ? config.pathPrefix : ''
     const staticUrls = options.staticUrls || []
 
+    // use today's day as lastmod, convert to W3C Datetime format
+    const today = new Date()
+    const yearMonthDay = [today.getFullYear(), today.getMonth(), today.getDate()]
+    const lastmod = yearMonthDay.map((date) => date.toString().padStart(2, '0')).join('-')
+
     let pages = queue.filter(page => page.type ? page.type === 'static' : true)
 
     if (include.length) {
@@ -46,7 +51,8 @@ module.exports = function (api, options) {
           ? url.substr(pathPrefix.length)
           : url,
         priority: urlConfig.priority,
-        changefreq: urlConfig.changefreq
+        changefreq: urlConfig.changefreq,
+        lastmod: urlConfig.lastmod,
       }
     })
 

--- a/packages/plugin-sitemap/index.js
+++ b/packages/plugin-sitemap/index.js
@@ -24,11 +24,6 @@ module.exports = function (api, options) {
     const pathPrefix = config.pathPrefix !== '/' ? config.pathPrefix : ''
     const staticUrls = options.staticUrls || []
 
-    // use today's day as lastmod, convert to W3C Datetime format
-    const today = new Date()
-    const yearMonthDay = [today.getFullYear(), today.getMonth(), today.getDate()]
-    const lastmod = yearMonthDay.map((date) => date.toString().padStart(2, '0')).join('-')
-
     let pages = queue.filter(page => page.type ? page.type === 'static' : true)
 
     if (include.length) {

--- a/packages/plugin-sitemap/index.js
+++ b/packages/plugin-sitemap/index.js
@@ -47,7 +47,7 @@ module.exports = function (api, options) {
           : url,
         priority: urlConfig.priority,
         changefreq: urlConfig.changefreq,
-        lastmod: urlConfig.lastmod,
+        lastmod: urlConfig.lastmod
       }
     })
 


### PR DESCRIPTION
Adds a `lastmod` option to the page config of `plugin-sitemap`, requested in https://github.com/gridsome/gridsome/issues/1147:

```javascript
config: {
  '/articles/*': {
    changefreq: 'weekly',
    priority: 0.5,
    lastmod: '2020-02-19'
  },
}
```