### PR TITLE
Pager.js: allow to set more classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 coverage
 dist
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 node_modules
 coverage
 dist
-.idea

--- a/gridsome/app/components/Pager.js
+++ b/gridsome/app/components/Pager.js
@@ -67,8 +67,7 @@ export default {
         }
       }, [text])
     }
-
-    const { linkClass }  = props
+    
     const links = showLinks
       ? pages.map(page => renderLink(page, page, props.ariaLinkLabel))
       : []

--- a/gridsome/app/components/Pager.js
+++ b/gridsome/app/components/Pager.js
@@ -10,9 +10,14 @@ export default {
     showLinks: { type: Boolean, default: true },
     showNavigation: { type: Boolean, default: true },
     firstLabel: { type: String, default: '«' },
+    firstClass: { type: String, default: '' },
     prevLabel: { type: String, default: '‹' },
+    prevClass: { type: String, default: '' },
     nextLabel: { type: String, default: '›' },
+    nextClass: { type: String, default: '' },
     lastLabel: { type: String, default: '»' },
+    lastClass: { type: String, default: '' },
+    navClass: { type: String, default: '' },
     linkClass: { type: String, default: '' },
     range: { type: Number, default: 5 },
     activeLinkClass: { type: String, default: undefined },
@@ -33,7 +38,7 @@ export default {
     const { current, total, pages, start, end } = resolveRange(info, props.range)
     const currentPath = stripPageParam(parent.$route)
 
-    const renderLink = (page, text = page, ariaLabel = text) => {
+    const renderLink = (page, text = page, ariaLabel = text, linkClass = '') => {
       if (page === current) ariaLabel = props.ariaCurrentLabel
 
       const linkProps = {
@@ -49,8 +54,12 @@ export default {
         linkProps.exactActiveClass = props.exactActiveLinkClass
       }
 
+      if (!Array.isArray(linkClass)) {
+        linkClass = [linkClass]
+      }
+
       return h(Link, {
-        class: props.linkClass,
+        class: [props.linkClass, ...linkClass],
         attrs: {
           ...linkProps,
           'aria-label': ariaLabel.replace('%n', page),
@@ -59,6 +68,7 @@ export default {
       }, [text])
     }
 
+    const { linkClass }  = props
     const links = showLinks
       ? pages.map(page => renderLink(page, page, props.ariaLinkLabel))
       : []
@@ -67,11 +77,12 @@ export default {
     if (showNavigation) {
       const { firstLabel, prevLabel, nextLabel, lastLabel } = props
       const { ariaFirstLabel, ariaPrevLabel, ariaNextLabel, ariaLastLabel } = props
+      const { firstClass, prevClass, nextClass, lastClass, navClass } = props
 
-      if (current > 1) links.unshift(renderLink(current - 1, prevLabel, ariaPrevLabel))
-      if (start > 0) links.unshift(renderLink(1, firstLabel, ariaFirstLabel))
-      if (current < total) links.push(renderLink(current + 1, nextLabel, ariaNextLabel))
-      if (end < total) links.push(renderLink(total, lastLabel, ariaLastLabel))
+      if (current > 1) links.unshift(renderLink(current - 1, prevLabel, ariaPrevLabel, [prevClass,navClass]))
+      if (start > 0) links.unshift(renderLink(1, firstLabel, ariaFirstLabel, [firstClass, navClass]))
+      if (current < total) links.push(renderLink(current + 1, nextLabel, ariaNextLabel, [nextClass, navClass]))
+      if (end < total) links.push(renderLink(total, lastLabel, ariaLastLabel, [lastClass, navClass]))
     }
 
     if (links.length < 2) return null
@@ -92,9 +103,9 @@ function createPagePath (path, page) {
 }
 
 function resolveRange ({
-  currentPage: current = 1,
-  totalPages: total = 1
-}, range) {
+                         currentPage: current = 1,
+                         totalPages: total = 1
+                       }, range) {
   const offset = Math.ceil(range / 2)
 
   let start = Math.floor(current - offset)

--- a/gridsome/app/components/Pager.js
+++ b/gridsome/app/components/Pager.js
@@ -4,7 +4,6 @@ import { unslashEnd, stripPageParam } from '../utils/helpers'
 // @vue/component
 export default {
   functional: true,
-
   props: {
     info: { type: Object, required: true },
     showLinks: { type: Boolean, default: true },
@@ -32,7 +31,6 @@ export default {
     ariaNextLabel: { type: String, default: 'Go to next page. Page %n' },
     ariaLastLabel: { type: String, default: 'Go to last page. Page %n' }
   },
-
   render: (h, { props, data, parent }) => {
     const { info, showLinks, showNavigation, ariaLabel } = props
     const { current, total, pages, start, end } = resolveRange(info, props.range)
@@ -54,12 +52,8 @@ export default {
         linkProps.exactActiveClass = props.exactActiveLinkClass
       }
 
-      if (!Array.isArray(linkClass)) {
-        linkClass = [linkClass]
-      }
-
       return h(Link, {
-        class: [props.linkClass, ...linkClass],
+        class: [props.linkClass, linkClass],
         attrs: {
           ...linkProps,
           'aria-label': ariaLabel.replace('%n', page),
@@ -67,7 +61,7 @@ export default {
         }
       }, [text])
     }
-    
+
     const links = showLinks
       ? pages.map(page => renderLink(page, page, props.ariaLinkLabel))
       : []
@@ -102,9 +96,9 @@ function createPagePath (path, page) {
 }
 
 function resolveRange ({
-                         currentPage: current = 1,
-                         totalPages: total = 1
-                       }, range) {
+   currentPage: current = 1,
+   totalPages: total = 1
+  }, range) {
   const offset = Math.ceil(range / 2)
 
   let start = Math.floor(current - offset)


### PR DESCRIPTION
Add more properties to Pajer.js component to allow users to set customs classes in navigation elements (First, Prev, Next, Last)

New properties
* firstClass: Custom class to the link to first element 
* prevClass: Custom class to the link to prev element 
* nextClass: Custom class to the link to first element 
* lastClass: Custom class to the link to last element 
* navClass: Custom class to all navigation elements (this class doesn't replace other custom classes

Add .idea/ to .gitignore