### PR TITLE
Fixed remark example links

### DIFF
--- a/packages/transformer-remark/README.md
+++ b/packages/transformer-remark/README.md
@@ -36,7 +36,7 @@ module.exports = {
 
 ## Add additional plugins
 
-By default this plugin comes with `remark-slug`, `remark-autolink-headings`, `remark-external-links`, `remark-squeeze-paragraphs` and `remark-fix-guillemets` included. Add any additional [Remark plugin](https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins) with a `plugins` option. Included plugins can also be disabled if needed. See more info below.
+By default this plugin comes with `remark-slug`, `remark-autolink-headings`, `remark-external-links`, `remark-squeeze-paragraphs` and `remark-fix-guillemets` included. Add any additional [Remark plugin](https://github.com/remarkjs/remark/blob/main/doc/plugins.md#list-of-plugins) with a `plugins` option. Included plugins can also be disabled if needed. See more info below.
 
 The following example adds the `remark-attr` plugin globally if it is installed in your project.
 
@@ -57,7 +57,7 @@ The following example adds the `remark-attr` plugin globally if it is installed 
 - Type: `Array`
 - Default: `[]`
 
-Add additional [Remark plugins](https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins).
+Add additional [Remark plugins](https://github.com/remarkjs/remark/blob/main/doc/plugins.md#list-of-plugins).
 
 ```js
 {
@@ -164,7 +164,7 @@ Support ASCII guillements (`<<`, `>>`) and mapping them to HTML.
 - Type: `Object`
 - Default: `{}`
 
-Add additional [Remark options](https://github.com/remarkjs/remark/blob/master/packages/remark-parse/readme.md#options).
+Add additional [Remark options](https://github.com/remarkjs/remark/blob/main/packages/remark-parse/readme.md#options).
 
 This allows you to enable/disable `gfm`, `commonmark`, `footnotes`,  `pedantic` and `blocks`.
 
@@ -186,7 +186,7 @@ This allows you to enable/disable `gfm`, `commonmark`, `footnotes`,  `pedantic` 
   
 * blocks
   * Type: `Array | string`
-  * Default: list of [block HTML elements](https://github.com/remarkjs/remark/blob/master/packages/remark-parse/lib/block-elements.js)
+  * Default: list of [block HTML elements](https://github.com/remarkjs/remark/blob/main/packages/remark-parse/lib/block-elements.js)
 
 ```js
 {


### PR DESCRIPTION
Changed repository in remark links towards the newly named _main_ repository