### PR TITLE
feat(graphql): add method to create pages node args

### DIFF
--- a/gridsome/lib/graphql/index.js
+++ b/gridsome/lib/graphql/index.js
@@ -4,7 +4,7 @@ const createSchema = require('./createSchema')
 const { GraphQLJSON } = require('graphql-compose')
 const { toFilterArgs } = require('./filters/query')
 const { createBelongsToKey } = require('./nodes/belongsTo')
-const { createPagedNodeEdges } = require('./nodes/utils')
+const { createPagedNodeEdges, createPagedNodeEdgesArgs } = require('./nodes/utils')
 
 module.exports = {
   ...graphql,
@@ -13,5 +13,6 @@ module.exports = {
   parseQuery,
   toFilterArgs,
   createBelongsToKey,
-  createPagedNodeEdges
+  createPagedNodeEdges,
+  createPagedNodeEdgesArgs
 }

--- a/gridsome/lib/graphql/nodes/belongsTo.js
+++ b/gridsome/lib/graphql/nodes/belongsTo.js
@@ -1,12 +1,12 @@
 const { ObjectTypeComposer } = require('graphql-compose')
-const { PER_PAGE, SORT_ORDER } = require('../../utils/constants')
 const { createFilterInput } = require('../filters/input')
 const { toFilterArgs } = require('../filters/query')
 const { safeKey } = require('../../utils')
 
 const {
   createSortOptions,
-  createPagedNodeEdges
+  createPagedNodeEdges,
+  createPagedNodeEdgesArgs
 } = require('./utils')
 
 exports.createBelongsToKey = function (node) {
@@ -39,13 +39,7 @@ exports.createBelongsTo = function (schemaComposer, store) {
     const filterTypeComposer = createFilterComposer(schemaComposer)
 
     const belongsToArgs = {
-      sortBy: { type: 'String', defaultValue: 'date' },
-      order: { type: 'SortOrder', defaultValue: SORT_ORDER },
-      perPage: { type: 'Int', description: `Defaults to ${PER_PAGE} when page is provided.` },
-      skip: { type: 'Int', defaultValue: 0 },
-      limit: { type: 'Int' },
-      page: { type: 'Int' },
-      sort: '[SortArgument!]',
+      ...createPagedNodeEdgesArgs('date'),
       filter: filterTypeComposer
     }
 

--- a/gridsome/lib/graphql/nodes/index.js
+++ b/gridsome/lib/graphql/nodes/index.js
@@ -1,7 +1,7 @@
 const graphql = require('../graphql')
 const camelCase = require('camelcase')
 const { createBelongsTo } = require('./belongsTo')
-const { PER_PAGE } = require('../../utils/constants')
+const { createPagedNodeEdgesArgs } = require('./utils')
 const { createFilterInput } = require('../filters/input')
 const createFieldDefinitions = require('../createFieldDefinitions')
 const { createFieldTypes } = require('../createFieldTypes')
@@ -236,13 +236,7 @@ function createTypeResolvers (typeComposer, collection) {
     name: 'findManyPaginated',
     type: `${typeName}Connection`,
     args: {
-      sortBy: { type: 'String', defaultValue: _defaultSortBy },
-      order: { type: 'SortOrder', defaultValue: _defaultSortOrder },
-      perPage: { type: 'Int', description: `Defaults to ${PER_PAGE} when page is provided.` },
-      skip: { type: 'Int', defaultValue: 0 },
-      limit: { type: 'Int' },
-      page: { type: 'Int' },
-      sort: { type: '[SortArgument]' },
+      ...createPagedNodeEdgesArgs(_defaultSortBy, _defaultSortOrder),
       filter: {
         type: `${typeName}FilterInput`,
         description: `Filter for ${typeName} nodes.`

--- a/gridsome/lib/graphql/nodes/utils.js
+++ b/gridsome/lib/graphql/nodes/utils.js
@@ -1,4 +1,4 @@
-const { PER_PAGE } = require('../../utils/constants')
+const { PER_PAGE, SORT_ORDER } = require('../../utils/constants')
 
 exports.applyChainArgs = function (chain, args = {}, sort = []) {
   if (sort.length) chain = applySort(chain, sort)
@@ -6,6 +6,24 @@ exports.applyChainArgs = function (chain, args = {}, sort = []) {
   if (args.limit) chain = chain.limit(args.limit)
 
   return chain
+}
+
+/**
+ * Create the arguments for {@link createPagedNodeEdges} method.
+ *
+ * @param {string} sortBy The field want used for sort
+ * @param {('ASC'|'DESC')} order The order of the sort
+ */
+exports.createPagedNodeEdgesArgs = function (sortBy, order = SORT_ORDER) {
+  return {
+    sortBy: { type: 'String', defaultValue: sortBy },
+    order: { type: 'SortOrder', defaultValue: order },
+    perPage: { type: 'Int', description: `Defaults to ${PER_PAGE} when page is provided.` },
+    skip: { type: 'Int', defaultValue: 0 },
+    limit: { type: 'Int' },
+    page: { type: 'Int' },
+    sort: '[SortArgument!]'
+  }
 }
 
 exports.createPagedNodeEdges = function (chain, args = {}, sort = []) {
@@ -83,4 +101,3 @@ function applySort (chain, sort = []) {
 
   return chain
 }
-


### PR DESCRIPTION
Hello,

I have create an method `createPagedNodeEdgesArgs` (and used in `createBelongsTo` and when create `NodeConnection`).
That method is useful for reuse in api for create paged nodes link below example :

```js
api.createSchema(({ addSchemaResolvers }) => {
  addSchemaResolvers({
    ProductCategory: {
      products: {
        type: 'ProductConnection',
        args: {
          ...createPagedNodeEdgesArgs('name', 'ASC'),
          depth: {
            type: 'Int',
            defaultValue: 0
          }
        },
        resolve (obj, args, { store }) {
          const categories = [obj.id, ...gqlUtils.getChildren(obj, store.getCollection('ProductCategory'), args.depth).map(children => children.id)] // `gqlUtils.getChildren` its my custom method
          const query = { parent: { $in: categories }, typeName: 'Product' }

          const sort = createSortOptions(args)
          return createPagedNodeEdges(store.chainIndex(query))
        }
      }
    }
  })
})
```

Thanks.