### PR TITLE
Add missing ref exists functions

### DIFF
--- a/gridsome/lib/graphql/filters/__tests__/query.spec.js
+++ b/gridsome/lib/graphql/filters/__tests__/query.spec.js
@@ -82,11 +82,13 @@ test('use custom loki operators for node references (single)', () => {
   const query2 = toFilterArgs({ author: { id: { ne: '1' } } }, itc)
   const query3 = toFilterArgs({ author: { id: { in: ['1'] } } }, itc)
   const query4 = toFilterArgs({ author: { id: { nin: ['1'] } } }, itc)
+  const query5 = toFilterArgs({ author: { id: { exists: false } } }, itc)
 
   expect(query1).toMatchObject({ author: { '$refEq': '1' } })
   expect(query2).toMatchObject({ author: { '$refNe': '1' } })
   expect(query3).toMatchObject({ author: { '$refIn': ['1'] } })
   expect(query4).toMatchObject({ author: { '$refNin': ['1'] } })
+  expect(query5).toMatchObject({ author: { '$refExists': false } })
 })
 
 test('use custom loki operators for node references (list)', () => {
@@ -105,11 +107,13 @@ test('use custom loki operators for node references (list)', () => {
   const query2 = toFilterArgs({ authors: { id: { ne: '1' } } }, itc)
   const query3 = toFilterArgs({ authors: { id: { in: ['1'] } } }, itc)
   const query4 = toFilterArgs({ authors: { id: { nin: ['1'] } } }, itc)
+  const query5 = toFilterArgs({ authors: { id: { exists: false } } }, itc)
 
   expect(query1).toMatchObject({ authors: { '$refListEq': '1' } })
   expect(query2).toMatchObject({ authors: { '$refListNe': '1' } })
   expect(query3).toMatchObject({ authors: { '$refListIn': ['1'] } })
   expect(query4).toMatchObject({ authors: { '$refListNin': ['1'] } })
+  expect(query5).toMatchObject({ authors: { '$refListExists': false } })
 })
 
 function createInputTypeComposer (config) {

--- a/gridsome/lib/graphql/filters/query.js
+++ b/gridsome/lib/graphql/filters/query.js
@@ -5,14 +5,16 @@ const listRefOpsMap = {
   '$in': '$refListIn',
   '$nin': '$refListNin',
   '$eq': '$refListEq',
-  '$ne': '$refListNe'
+  '$ne': '$refListNe',
+  '$exists': '$refListExists'
 }
 
 const refOpsMap = {
   '$in': '$refIn',
   '$nin': '$refNin',
   '$eq': '$refEq',
-  '$ne': '$refNe'
+  '$ne': '$refNe',
+  '$exists': '$refExists'
 }
 
 function toFilterArgs (filter, typeComposer, currentKey = '') {

--- a/gridsome/lib/store/__tests__/lokiOps.spec.js
+++ b/gridsome/lib/store/__tests__/lokiOps.spec.js
@@ -3,10 +3,12 @@ const {
   $refListNin,
   $refListEq,
   $refListNe,
+  $refListExists,
   $refIn,
   $refNin,
   $refEq,
-  $refNe
+  $refNe,
+  $refExists
 } = require('../lokiOps')
 
 test('$refListIn', () => {
@@ -45,6 +47,16 @@ test('$refListNe', () => {
   expect($refListNe(null)).toEqual(true)
 })
 
+test('$refListExists', () => {
+  expect($refListExists(['1', '2', '3'], false)).toEqual(false)
+  expect($refListExists(['1', '2', '3'], true)).toEqual(true)
+  expect($refListExists([{ id: '1' }, { id: '2' }], true)).toEqual(true)
+  expect($refListExists([{ id: undefined }, { id: undefined }], false)).toEqual(true)
+  expect($refListExists([{ id: undefined }, { id: undefined }], true)).toEqual(false)
+  expect($refListExists(null, false)).toEqual(false)
+  expect($refListExists(null)).toEqual(false)
+})
+
 test('$refIn', () => {
   expect($refIn('2', ['1', '2'])).toEqual(true)
   expect($refIn('3', ['1', '2'])).toEqual(false)
@@ -76,4 +88,18 @@ test('$refNe', () => {
   expect($refNe({ id: '3' }, '2')).toEqual(true)
   expect($refNe({ id: '3' })).toEqual(true)
   expect($refNe(null)).toEqual(true)
+})
+
+test('$refExists', () => {
+  expect($refExists('2', false)).toEqual(false)
+  expect($refExists('2', true)).toEqual(true)
+  expect($refExists(undefined, false)).toEqual(true)
+  expect($refExists(undefined, true)).toEqual(false)
+  expect($refExists({ id: '2' }, false)).toEqual(false)
+  expect($refExists({ id: '2' }, true)).toEqual(true)
+  expect($refExists({ id: undefined }, false)).toEqual(true)
+  expect($refExists({ id: undefined }, true)).toEqual(false)
+  expect($refExists({ id: '2' })).toEqual(false)
+  expect($refExists(null, false)).toEqual(false)
+  expect($refExists(null)).toEqual(false)
 })

--- a/gridsome/lib/store/lokiOps.js
+++ b/gridsome/lib/store/lokiOps.js
@@ -8,6 +8,7 @@ const $refIn = (a, b) => isArray(b) && b.some(v => refCheckFn(a, v))
 const $refNin = (a, b) => !$refIn(a, b)
 const $refEq = (a, b) => refCheckFn(a, b)
 const $refNe = (a, b) => !$refEq(a, b)
+const $refExists = (a, b) => b ? !$refEq(a, undefined) : $refEq(a, undefined)
 const $refListIn = (a, b) => isArray(a)
   ? a.some(v => $refIn(v, b))
   : false
@@ -16,14 +17,17 @@ const $refListEq = (a, b) => isArray(a)
   ? a.some(v => $refEq(v, b))
   : false
 const $refListNe = (a, b) => !$refListEq(a, [b])
+const $refListExists = (a, b) => b ? !$refListEq(a, undefined) : $refListEq(a, undefined)
 
 module.exports = {
   $refIn,
   $refNin,
   $refEq,
   $refNe,
+  $refExists,
   $refListIn,
   $refListNin,
   $refListEq,
-  $refListNe
+  $refListNe,
+  $refListExists
 }


### PR DESCRIPTION
Hello,

This add missing loki operator `$refExists` and `$refListExists`.
That fix `Error: fun is not function` when we have an request like :
```gql
query {
  allProductCategory(filter: { parent: { id: { exists: false } } }) {
    totalCount
    edges {
      node {
        name
        parent {
          id
        }
      }
    }
  }
}
```

Thanks