### PR TITLE
feature: add option to toggle line numbers alongside code

### DIFF
--- a/packages/remark-prismjs/README.md
+++ b/packages/remark-prismjs/README.md
@@ -74,6 +74,16 @@ If you'd like to disable highlighting of inline code blocks, pass `transformInli
 - Type: `Boolean`
 - Default: `false`
 
-If you'd like to add line numbers alongside the code. pass `showLineNumbers: true` in the plugin options
+If you'd like to add line numbers alongside the code. You can pass `showLineNumbers: true` in the plugin options and import a Prism CSS about line numbers to `main.js` file. like this:
 
-If you wish to only show line numbers on certain code blocks, you can leave `false` and use the `{ numberLines: true }` syntax below
+```js
+import 'prismjs/themes/prism.css'
+// Prism default CSS about line numbers
+import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
+
+export default function (Vue) {
+  // ...
+}
+```
+
+If you wish to only show line numbers on certain code blocks, you can leave `false` and use the `{ lineNumbers: true }` syntax below

--- a/packages/remark-prismjs/README.md
+++ b/packages/remark-prismjs/README.md
@@ -60,23 +60,20 @@ module.exports = {
 }
 ```
 
+## Options
+
+#### transformInlineCode
+
+- Type: `Boolean`
+- Default: `false`
+
 If you'd like to disable highlighting of inline code blocks, pass `transformInlineCode: false` in the plugin options
 
-```js
-module.exports = {
-  plugins: [
-    {
-      use: '@gridsome/source-filesystem',
-      options: {}
-    }
-  ],
+#### showLineNumbers
 
-  transformers: {
-    remark: {
-      plugins: [
-        ['@gridsome/remark-prismjs', { transformInlineCode: false }]
-      ]
-    }
-  }
-}
-```
+- Type: `Boolean`
+- Default: `false`
+
+If you'd like to add line numbers alongside the code. pass `showLineNumbers: true` in the plugin options
+
+If you wish to only show line numbers on certain code blocks, you can leave `false` and use the `{ numberLines: true }` syntax below

--- a/packages/remark-prismjs/index.js
+++ b/packages/remark-prismjs/index.js
@@ -70,7 +70,7 @@ function createCode (node, showLineNumbersGlobal) {
 
   const {
     showLineNumbersLocal,
-    numberLinesStartAt
+    lineNumbersStartAt
   } = parseOptions(node.meta || '')
 
   const data = node.data || {}
@@ -94,9 +94,9 @@ function createCode (node, showLineNumbersGlobal) {
       'pre',
       {
         className: [className, 'line-numbers'],
-        style: numberLinesStartAt - 1
+        style: lineNumbersStartAt - 1
           ? {
-            'counter-reset': `linenumber ${numberLinesStartAt - 1}`
+            'counter-reset': `linenumber ${lineNumbersStartAt - 1}`
           }
           : null,
         ...props

--- a/packages/remark-prismjs/index.js
+++ b/packages/remark-prismjs/index.js
@@ -78,23 +78,30 @@ function createCode (node, showLineNumbersGlobal) {
   const className = `language-${lang}`
   const showLineNumbers = showLineNumbersLocal || showLineNumbersGlobal
 
-  const codeNode = h('code', { className }, u('raw', code))
+  const codeNode = showLineNumbers
+    ? h(
+      'code',
+      { className },
+      [
+        u('raw', code),
+        createLineNumberWrapper(code)
+      ]
+    )
+    : h('code', { className }, [u('raw', code)])
+
   const preNode = showLineNumbers
     ? h(
       'pre',
       {
         className: [className, 'line-numbers'],
-        style: {
-          'counter-reset': numberLinesStartAt - 1
-            ? `linenumber ${numberLinesStartAt - 1}`
-            : null
-        },
+        style: numberLinesStartAt - 1
+          ? {
+            'counter-reset': `linenumber ${numberLinesStartAt - 1}`
+          }
+          : null,
         ...props
       },
-      [
-        codeNode,
-        createLineNumberWrapper(code)
-      ]
+      [codeNode]
     )
     : h('pre', { className, ...props }, [codeNode])
 

--- a/packages/remark-prismjs/parse-options.js
+++ b/packages/remark-prismjs/parse-options.js
@@ -1,0 +1,34 @@
+module.exports = (meta) => {
+  let showLineNumbersLocal = false
+  let numberLinesStartAt = 1
+
+  if (meta.split(`{`).length > 1) {
+    const [, ...options] = meta.split(`{`)
+
+    options.forEach(option => {
+      const splitOption = option
+        .slice(0, -1)
+        .replace(/ /g, ``)
+        .split(`:`)
+
+      if (
+        splitOption.length === 2 &&
+        splitOption[0] === 'numberLines' &&
+        (
+          splitOption[1].trim() === 'true' ||
+          Number.isInteger(parseInt(splitOption[1].trim(), 10))
+        )
+      ) {
+        showLineNumbersLocal = true
+        numberLinesStartAt = splitOption[1].trim() !== 'true'
+          ? parseInt(splitOption[1].trim(), 10)
+          : 1
+      }
+    })
+  }
+
+  return {
+    showLineNumbersLocal,
+    numberLinesStartAt
+  }
+}

--- a/packages/remark-prismjs/parse-options.js
+++ b/packages/remark-prismjs/parse-options.js
@@ -1,6 +1,6 @@
 module.exports = (meta) => {
   let showLineNumbersLocal = false
-  let numberLinesStartAt = 1
+  let lineNumbersStartAt = 1
 
   if (meta.split(`{`).length > 1) {
     const [, ...options] = meta.split(`{`)
@@ -13,14 +13,14 @@ module.exports = (meta) => {
 
       if (
         splitOption.length === 2 &&
-        splitOption[0] === 'numberLines' &&
+        splitOption[0] === 'lineNumbers' &&
         (
           splitOption[1].trim() === 'true' ||
           Number.isInteger(parseInt(splitOption[1].trim(), 10))
         )
       ) {
         showLineNumbersLocal = true
-        numberLinesStartAt = splitOption[1].trim() !== 'true'
+        lineNumbersStartAt = splitOption[1].trim() !== 'true'
           ? parseInt(splitOption[1].trim(), 10)
           : 1
       }
@@ -29,6 +29,6 @@ module.exports = (meta) => {
 
   return {
     showLineNumbersLocal,
-    numberLinesStartAt
+    lineNumbersStartAt
   }
 }


### PR DESCRIPTION
I add option `showLineNumbers: true` to display line numbers for `@gridsome/remark-prismjs`, and also tried to update the doc

this feature be mentioned at #1035  and #1048 

## Example:

set in `gridsome.config.js` 

```js
{
  remark: {
    plugins: [
      [
        require('./script/remark-prismjs'),
        {
          // display line numbers alongside code
          showLineNumbers: true
        }
      ]
    ]
  }
}
```
or if wish to only show line numbers on certain code blocks, leave false and use the `{ numberLines: true | number }` syntax below

````markdown
```js { numberLines: 21 }
interface IntersectionObserver {
  readonly root: Element | null;
  readonly rootMargin: string;
  readonly thresholds: ReadonlyArray<number>;
  disconnect(): void;
  observe(target: Element): void;
  takeRecords(): IntersectionObserverEntry[];
  unobserve(target: Element): void;
}
```
````

that will output this

![image](https://user-images.githubusercontent.com/39984251/86300417-5bf08780-bc35-11ea-9b48-f9dc01a5c1e7.png)