### PR TITLE
Fix `g-image` not adding `height` attribute

### DIFF
--- a/gridsome/app/components/Image.js
+++ b/gridsome/app/components/Image.js
@@ -40,6 +40,7 @@ export default {
 
         attrs.src = isLazy ? dataUri : src
         attrs.width = size.width
+        attrs.height = size.height
 
         if (isLazy) attrs['data-src'] = src
         if (srcset.length) attrs[`${isLazy ? 'data-' : ''}srcset`] = Array.isArray(srcset) ? srcset.join(', ') : srcset


### PR DESCRIPTION
This PR fixes an issue where the browser wouldn't be able to save space for images even when this info was available 😢 

> Use both width and height to set the intrinsic size of the image, allowing it to take up space before it loads, to mitigate content layout shifts. 
> [`<img>`: The Image Embed element - HTML: Hypertext Markup Language | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img)