### PR TITLE
fix(vue-remark): add support VueComponent function

### DIFF
--- a/packages/vue-remark/lib/codegen.js
+++ b/packages/vue-remark/lib/codegen.js
@@ -42,6 +42,8 @@ exports.genImportBlock = function (statements, file) {
     `  Object.keys(imported).forEach(function (key) {\n` +
     `    if (typeof imported[key] === 'object' && typeof imported[key].render === 'function') {\n` +
     `      components[key] = imported[key]\n` +
+    `    } else if (typeof imported[key] === 'function' && typeof imported[key].options.render === 'function') {\n` +
+    `      components[key] = imported[key]\n` +
     `    } else {\n` +
     `      computed[key] = function () {\n` +
     `        return imported[key]\n` +


### PR DESCRIPTION
Hello,

When create component with vue-class-component or Vue.extend
import return an VueComponent function not an Object.

So, i have added an branch in if to support this case

I test and don't change original behavior and work fine with the two form.
Also work fine with components in typescript (with vue-class-component in my case)