### PR TITLE
fix(remark): add option to control wrapper of images (#700, #1195)

### DIFF
--- a/packages/transformer-remark/lib/plugins/image.js
+++ b/packages/transformer-remark/lib/plugins/image.js
@@ -9,7 +9,31 @@ module.exports = function attacher (options = {}) {
 
     const images = []
 
-    visit(tree, 'image', node => images.push(node))
+    if (typeof options.wrapper !== 'undefined') {
+      visit(tree, 'paragraph', (node, index, parent) => {
+        let hasImage = false
+        node.children.forEach(children => {
+          if (children.type === 'image') {
+            hasImage = true
+            images.push(children)
+          }
+        })
+        if (hasImage) {
+          if (options.wrapper === false) {
+            parent.children.splice(index, 1, ...node.children)
+          } else if (typeof options.wrapper === 'string') {
+            node.type = options.wrapper
+            node.data = {
+              hName: options.wrapper
+            }
+          } else if (typeof options.wrapper === 'function') {
+            return options.wrapper(node, index, parent)
+          }
+        }
+      })
+    } else {
+      visit(tree, 'image', node => images.push(node))
+    }
 
     for (const node of images) {
       const data = node.data || {}

--- a/packages/transformer-remark/lib/utils.js
+++ b/packages/transformer-remark/lib/utils.js
@@ -36,7 +36,8 @@ exports.createPlugins = function (options, localOptions) {
       blur: options.imageBlurRatio,
       quality: options.imageQuality,
       background: options.imageBackground,
-      immediate: options.lazyLoadImages === false ? true : undefined
+      immediate: options.lazyLoadImages === false ? true : undefined,
+      wrapper: options.wrapperImages
     }])
   }
 


### PR DESCRIPTION
add an option `wrapperImages` for [@gridsome/transformer-remark](https://gridsome.org/plugins/@gridsome/transformer-remark) to control the wrapper of images.

`wrapperImages` can be:

- `false`: simply remove wrapper
- `string`: name of tag to wrap images (ex: figure)
- `function`: the function permit all custom modify

the `function` receive:

- **node**: node tree of paragraph
- **index**: index of node in tree
- **parent**: the parent of node

# example
``` javascript
{
  use: '@gridsome/source-filesystem',
    options: {
    path: 'content/**/*.md',
      typeName: 'BlogPost',
        remark: {
      wrapperImages: (node) => {
        node.type = 'figure'
        node.data = {
          hNames: 'figure',
          hProperties: {
            className: 'figure-image'
          }
        }
      }
    }
  }
}
```

This configuration render something like this in html
```html
<figure class="figure-image">
  <img src="myImage.png">
</figure>
```