### PR TITLE
Source-strapi media download

### DIFF
--- a/packages/source-strapi/CHANGELOG.md
+++ b/packages/source-strapi/CHANGELOG.md
@@ -8,4 +8,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
+Option to download media source from strapi into a proper folder. 
+
+
 * **strapi:** initial strapi source plugin ([#217](https://github.com/gridsome/gridsome/tree/master/packages/source-strapi/issues/217)) ([7186ff1](https://github.com/gridsome/gridsome/tree/master/packages/source-strapi/commit/7186ff1))

--- a/packages/source-strapi/helpers/query.js
+++ b/packages/source-strapi/helpers/query.js
@@ -1,8 +1,8 @@
 const axios = require('axios')
 const pluralize = require('pluralize')
 const execSync = require('child_process').execSync
-const path = require("path")
-const fs = require("fs")
+const path = require('path')
+const fs = require('fs')
 
 function downloadMedia (image, apiUrl) {
   const { url, sha256, ext } = image
@@ -13,11 +13,11 @@ function downloadMedia (image, apiUrl) {
     method: 'GET',
     responseType: 'stream'
   })
-  .then(response => [response.data, imageUrl])
-  .catch(e => {
-    console.error(remoteUrl, e)
-    throw Error(e)
-  })
+    .then(response => [response.data, imageUrl])
+    .catch(e => {
+      console.error(remoteUrl, e)
+      throw Error(e)
+    })
 }
 
 function saveImage (data, imageUrl, mediaFolder) {
@@ -31,7 +31,7 @@ function saveImage (data, imageUrl, mediaFolder) {
   })
 }
 
-function downloadAllMedia(data, apiURL, params, mediaFolder) {
+function downloadAllMedia (data, apiURL, params, mediaFolder) {
   params.map(p => {
     if (data[p]) {
       const mediaArray = Array.isArray(data[p]) ? data[p] : [data[p]]

--- a/packages/source-strapi/helpers/query.js
+++ b/packages/source-strapi/helpers/query.js
@@ -1,7 +1,50 @@
 const axios = require('axios')
 const pluralize = require('pluralize')
+const execSync = require('child_process').execSync
+const path = require("path")
+const fs = require("fs")
 
-module.exports = async ({ apiURL, resourceName, jwtToken, queryLimit, isSingleType }) => {
+function downloadMedia (image, apiUrl) {
+  const { url, sha256, ext } = image
+  const imageUrl = `${sha256}${ext}`
+
+  const remoteUrl = `${apiUrl}${url}`
+  return axios.get(remoteUrl, {
+    method: 'GET',
+    responseType: 'stream'
+  })
+  .then(response => [response.data, imageUrl])
+  .catch(e => {
+    console.error(remoteUrl, e)
+    throw Error(e)
+  })
+}
+
+function saveImage (data, imageUrl, mediaFolder) {
+  return new Promise((resolve, reject) => {
+    const mediaPath = path.resolve(mediaFolder, imageUrl)
+    const writer = fs.createWriteStream(mediaPath)
+
+    data.pipe(writer)
+    writer.on('finish', resolve)
+    writer.on('error', reject)
+  })
+}
+
+function downloadAllMedia(data, apiURL, params, mediaFolder) {
+  params.map(p => {
+    if (data[p]) {
+      const mediaArray = Array.isArray(data[p]) ? data[p] : [data[p]]
+      mediaArray.map(media => {
+        downloadMedia(media, apiURL)
+          .then(([mediaData, name]) => saveImage(mediaData, name, mediaFolder))
+          .catch(e => console.error(e))
+      })
+    }
+  })
+}
+
+module.exports = async ({ apiURL, resourceName, jwtToken, queryLimit, isSingleType, mediaDownloadFolder, mediaDownloadParameters }) => {
   let resource
   if (isSingleType) {
     resource = resourceName
@@ -23,6 +66,15 @@ module.exports = async ({ apiURL, resourceName, jwtToken, queryLimit, isSingleTy
   // Make API request.
   return axios(apiEndpoint, fetchRequestConfig)
     .then(res => res.data)
+    .then(async data => {
+      if (mediaDownloadFolder) {
+        await execSync(`mkdir -p ${mediaDownloadFolder}`)
+        data.map(dataItem => {
+          downloadAllMedia(dataItem, apiURL, mediaDownloadParameters, mediaDownloadFolder)
+        })
+      }
+      return data
+    })
     .catch(err => {
       console.error(`Unable to get content type (${resource}). Did you enable permissions in the Strapi admin for this?`)
       throw err

--- a/packages/source-strapi/index.js
+++ b/packages/source-strapi/index.js
@@ -4,7 +4,7 @@ const { trimEnd, upperFirst, camelCase } = require('lodash')
 
 module.exports = function (api, options) {
   api.loadSource(async ({ addCollection }) => {
-    const { queryLimit, contentTypes, singleTypes, loginData } = options
+    const { queryLimit, contentTypes, singleTypes, loginData, mediaDownloadFolder, mediaDownloadParameters } = options
     const apiURL = trimEnd(options.apiURL, '/')
     let jwtToken = null
 
@@ -36,18 +36,34 @@ module.exports = function (api, options) {
         const typeName = upperFirst(camelCase(`${options.typeName} ${resourceName}`))
         const collection = addCollection({ typeName, dateField: 'created_at' })
         const isSingleType = false
-        return query({ apiURL, resourceName, jwtToken, queryLimit, isSingleType })
-          .then(docs => docs.forEach(doc => {
-            collection.addNode(doc)
-          })
-          )
+        return query({
+          apiURL,
+          resourceName,
+          jwtToken,
+          queryLimit,
+          isSingleType,
+          mediaDownloadFolder,
+          mediaDownloadParameters
+        })
+        .then(docs => docs.forEach(doc => {
+          collection.addNode(doc)
+        })
+        )
       })),
       Promise.all(singleTypes.map(resourceName => {
         const typeName = upperFirst(camelCase(`${options.typeName} ${resourceName}`))
         const collection = addCollection({ typeName, dateField: 'created_at' })
         const isSingleType = true
-        return query({ apiURL, resourceName, jwtToken, queryLimit, isSingleType })
-          .then(data => collection.addNode(data))
+        return query({
+          apiURL,
+          resourceName,
+          jwtToken,
+          queryLimit,
+          isSingleType,
+          mediaDownloadFolder,
+          mediaDownloadParameters
+         })
+        .then(data => collection.addNode(data))
       }))]
     )
   })
@@ -59,5 +75,7 @@ module.exports.defaultOptions = () => ({
   singleTypes: [],
   loginData: {},
   queryLimit: 100,
-  typeName: 'Strapi'
+  typeName: 'Strapi',
+  mediaDownloadFolder: undefined,
+  mediaDownloadParameters: []
 })

--- a/packages/source-strapi/index.js
+++ b/packages/source-strapi/index.js
@@ -45,10 +45,10 @@ module.exports = function (api, options) {
           mediaDownloadFolder,
           mediaDownloadParameters
         })
-        .then(docs => docs.forEach(doc => {
-          collection.addNode(doc)
-        })
-        )
+          .then(docs => docs.forEach(doc => {
+            collection.addNode(doc)
+          })
+          )
       })),
       Promise.all(singleTypes.map(resourceName => {
         const typeName = upperFirst(camelCase(`${options.typeName} ${resourceName}`))
@@ -62,8 +62,8 @@ module.exports = function (api, options) {
           isSingleType,
           mediaDownloadFolder,
           mediaDownloadParameters
-         })
-        .then(data => collection.addNode(data))
+        })
+          .then(data => collection.addNode(data))
       }))]
     )
   })

--- a/packages/source-strapi/package-lock.json
+++ b/packages/source-strapi/package-lock.json
@@ -1,0 +1,43 @@
+{
+  "name": "@gridsome/source-strapi",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+    },
+    "fs-extra": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+    },
+    "jsonfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^1.0.0"
+      }
+    },
+    "universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+    }
+  }
+}

--- a/packages/source-strapi/package.json
+++ b/packages/source-strapi/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "axios": "^0.19.0",
+    "fs-extra": "^9.0.1",
     "lodash": "^4.17.11",
     "pluralize": "^7.0.0"
   }


### PR DESCRIPTION
Hi guys,

In so excited because this is my first contribution to an open-source project.

In my company, we used Gridsome combined with Strapi and we noticed that the images stored in Strapi are not downloaded from the remote server using the source-strapi package.
So I thought to create a custom code to do the media download in the api.loadSource.

I'm absolutely open to criticism as I want to learn as much as I can from the community.
What do you think about this feature? 

I had to adapt my script to be used into the package, but I tested it and works fine with images.


For this feature, I add two arguments in the options that can be added also in the doc if you agree with the introduction of this feature. 

mediaDownloadFolder: the absolute path of the destination directory 
(Can be in some way relative path? I did not know how can be implemented with relative path)

mediaDownloadParameters (can have a better name?): the key names of the media in the root that has to be downloaded. 

For now, only images in the object root are detected but can be easily implemented the code for detect parameters along the object.
For example can be implemented a sintax like "object1.object2.imageToBeDownloaded".

Sorry for my poor explanation. Hope I was clear. English is not my native language. 