### PR TITLE
feat: support Yarn PnP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,21 @@ jobs:
           name: Run unit tests
           command: yarn run test:unit
 
+  test-pnp:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: |
+          git clone https://github.com/gridsome/gridsome-starter-default.git pnp-e2e
+          cd pnp-e2e
+          touch yarn.lock
+          yarn set version 2
+          yarn config set pnpFallbackMode none
+          yarn config set compressionLevel 0
+          yarn link -A ../
+          yarn build
+
 workflows:
   version: 2
   lint-and-test:
@@ -54,5 +69,8 @@ workflows:
           requires:
             - install
       - test-unit:
+          requires:
+            - install
+      - test-pnp:
           requires:
             - install

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 coverage
 dist
+pnp-e2e

--- a/gridsome/lib/app/loadConfig.js
+++ b/gridsome/lib/app/loadConfig.js
@@ -405,7 +405,10 @@ function resolvePluginEntries (id, context) {
   } else if (id.startsWith('~/')) {
     dirName = path.join(context, id.replace(/^~\//, ''))
   } else {
-    dirName = path.dirname(require.resolve(id))
+    // TODO: Replace with require.resolve(id, { paths: [context] }) when support for node is >= v8.9.0    
+    // https://nodejs.org/api/modules.html#modules_require_resolve_request_options
+    const resolvedPath = require('resolve-from')(context, id)
+    dirName = path.dirname(resolvedPath)
   }
 
   if (

--- a/gridsome/lib/develop.js
+++ b/gridsome/lib/develop.js
@@ -126,8 +126,8 @@ module.exports = async (context, args) => {
 
     config.entryPoints.store.forEach((entry, name) => {
       config.entry(name)
-        .prepend(`webpack-hot-middleware/client?name=${name}&reload=true&noInfo=true`)
-        .prepend('webpack/hot/dev-server')
+        .prepend(`${require.resolve('webpack-hot-middleware/client')}?name=${name}&reload=true&noInfo=true`)
+        .prepend(require.resolve('webpack/hot/dev-server'))
     })
 
     return app.compiler.resolveWebpackConfig(false, config)

--- a/gridsome/lib/plugins/vue-components/index.js
+++ b/gridsome/lib/plugins/vue-components/index.js
@@ -33,7 +33,7 @@ class VueComponents {
     config.module.rule(type)
       .resourceQuery(re)
       .use('babel-loader')
-      .loader('babel-loader')
+      .loader(require.resolve('babel-loader'))
       .options({
         presets: [
           require.resolve('@vue/babel-preset-app')

--- a/gridsome/lib/plugins/vue-components/index.js
+++ b/gridsome/lib/plugins/vue-components/index.js
@@ -37,6 +37,9 @@ class VueComponents {
       .options({
         presets: [
           require.resolve('@vue/babel-preset-app')
+        ],
+        plugins: [
+          require.resolve('../../webpack/plugins/corejsBabelPlugin.js')
         ]
       })
       .end()

--- a/gridsome/lib/server/createRenderFn.js
+++ b/gridsome/lib/server/createRenderFn.js
@@ -20,7 +20,8 @@ module.exports = function createRenderFn ({
     clientManifest,
     runInNewContext: false,
     shouldPrefetch,
-    shouldPreload
+    shouldPreload,
+    basedir: __dirname
   })
 
   return async function render(page, state, stateSize, hash) {

--- a/gridsome/lib/webpack/createBaseConfig.js
+++ b/gridsome/lib/webpack/createBaseConfig.js
@@ -72,7 +72,9 @@ module.exports = (app, { isProd, isServer }) => {
   config.module.noParse(/^(vue|vue-router|vue-meta)$/)
 
   if (app.config.runtimeCompiler) {
-    config.resolve.alias.set('vue$', 'vue/dist/vue.esm.js')
+    config.resolve.alias.set('vue$', require.resolve('vue/dist/vue.esm.js'))
+  } else {
+    config.resolve.alias.set('vue$', path.dirname(require.resolve('vue/package.json')))
   }
 
   if (!isProd) {

--- a/gridsome/lib/webpack/createBaseConfig.js
+++ b/gridsome/lib/webpack/createBaseConfig.js
@@ -40,10 +40,6 @@ module.exports = (app, { isProd, isServer }) => {
     .extensions
     .merge(['.js', '.vue'])
     .end()
-    .modules
-    .add(resolve('../../node_modules'))
-    .add(resolve('../../../packages'))
-    .add('node_modules')
 
   config.resolve
     .plugin('gridsome-fallback-resolver-plugin')
@@ -63,11 +59,6 @@ module.exports = (app, { isProd, isServer }) => {
       .use({ ...require('pnp-webpack-plugin').topLevelLoader })
       .end()
     .set('symlinks', true)
-    .modules
-      .add(resolve('./loaders'))
-      .add(resolve('../../node_modules'))
-      .add(resolve('../../../packages'))
-      .add('node_modules')
 
   config.module.noParse(/^(vue|vue-router|vue-meta)$/)
 

--- a/gridsome/lib/webpack/createBaseConfig.js
+++ b/gridsome/lib/webpack/createBaseConfig.js
@@ -150,6 +150,9 @@ module.exports = (app, { isProd, isServer }) => {
             resolve('../../app/entry.client.js')
           ]
         }]
+      ],
+      plugins: [
+        require.resolve('./plugins/corejsBabelPlugin.js')
       ]
     })
 

--- a/gridsome/lib/webpack/createBaseConfig.js
+++ b/gridsome/lib/webpack/createBaseConfig.js
@@ -52,14 +52,22 @@ module.exports = (app, { isProd, isServer }) => {
         optionalDir: path.join(app.context, 'src'),
         resolve: ['main', 'App.vue']
       }])
-
+      .end()
+    // TODO: Remove plugin when using webpack 5
+    .plugin('pnp')
+      .use({...require(`pnp-webpack-plugin`)})
+    
   config.resolveLoader
+    // TODO: Remove plugin when using webpack 5
+    .plugin('pnp-loaders')
+      .use({ ...require('pnp-webpack-plugin').topLevelLoader })
+      .end()
     .set('symlinks', true)
     .modules
-    .add(resolve('./loaders'))
-    .add(resolve('../../node_modules'))
-    .add(resolve('../../../packages'))
-    .add('node_modules')
+      .add(resolve('./loaders'))
+      .add(resolve('../../node_modules'))
+      .add(resolve('../../../packages'))
+      .add('node_modules')
 
   config.module.noParse(/^(vue|vue-router|vue-meta)$/)
 

--- a/gridsome/lib/webpack/createBaseConfig.js
+++ b/gridsome/lib/webpack/createBaseConfig.js
@@ -303,7 +303,11 @@ module.exports = (app, { isProd, isServer }) => {
         }))
 
       if (loader) {
-        rule.use(loader).loader(loader).options(options)
+        try {
+          rule.use(loader).loader(require.resolve(loader)).options(options)
+        } catch {
+          rule.use(loader).loader(loader).options(options)
+        }
       }
     }
   }

--- a/gridsome/lib/webpack/createBaseConfig.js
+++ b/gridsome/lib/webpack/createBaseConfig.js
@@ -76,14 +76,14 @@ module.exports = (app, { isProd, isServer }) => {
   config.module.rule('vue')
     .test(/\.vue$/)
     .use('cache-loader')
-    .loader('cache-loader')
+    .loader(require.resolve('cache-loader'))
     .options({
       cacheDirectory,
       cacheIdentifier
     })
     .end()
     .use('vue-loader')
-    .loader('vue-loader')
+    .loader(require.resolve('vue-loader'))
     .options({
       compilerOptions: {
         preserveWhitespace: false,
@@ -126,14 +126,14 @@ module.exports = (app, { isProd, isServer }) => {
     })
     .end()
     .use('cache-loader')
-    .loader('cache-loader')
+    .loader(require.resolve('cache-loader'))
     .options({
       cacheDirectory,
       cacheIdentifier
     })
     .end()
     .use('babel-loader')
-    .loader('babel-loader')
+    .loader(require.resolve('babel-loader'))
     .options({
       presets: [
         [require.resolve('@vue/babel-preset-app'), {
@@ -159,7 +159,7 @@ module.exports = (app, { isProd, isServer }) => {
   config.module.rule('images')
     .test(/\.(png|jpe?g|gif|webp)(\?.*)?$/)
     .use('url-loader')
-    .loader('url-loader')
+    .loader(require.resolve('url-loader'))
     .options({
       limit: inlineLimit,
       name: `${assetsDir}/img/${assetname}`
@@ -168,7 +168,7 @@ module.exports = (app, { isProd, isServer }) => {
   config.module.rule('svg')
     .test(/\.(svg)(\?.*)?$/)
     .use('file-loader')
-    .loader('file-loader')
+    .loader(require.resolve('file-loader'))
     .options({
       name: `${assetsDir}/img/${assetname}`
     })
@@ -176,7 +176,7 @@ module.exports = (app, { isProd, isServer }) => {
   config.module.rule('media')
     .test(/\.(mp4|webm|ogg|mp3|wav|flac|aac)(\?.*)?$/)
     .use('url-loader')
-    .loader('url-loader')
+    .loader(require.resolve('url-loader'))
     .options({
       limit: inlineLimit,
       name: `${assetsDir}/media/${assetname}`
@@ -185,7 +185,7 @@ module.exports = (app, { isProd, isServer }) => {
   config.module.rule('fonts')
     .test(/\.(woff2?|eot|ttf|otf)(\?.*)?$/i)
     .use('url-loader')
-    .loader('url-loader')
+    .loader(require.resolve('url-loader'))
     .options({
       limit: inlineLimit,
       name: `${assetsDir}/fonts/${assetname}`
@@ -196,10 +196,10 @@ module.exports = (app, { isProd, isServer }) => {
   config.module.rule('yaml')
     .test(/\.ya?ml$/)
     .use('json-loader')
-    .loader('json-loader')
+    .loader(require.resolve('json-loader'))
     .end()
     .use('yaml-loader')
-    .loader('yaml-loader')
+    .loader(require.resolve('yaml-loader'))
 
   // plugins
 
@@ -280,12 +280,12 @@ module.exports = (app, { isProd, isServer }) => {
         if (isProd) {
           rule.use('extract-css-loader').loader(CSSExtractPlugin.loader)
         } else {
-          rule.use('vue-style-loader').loader('vue-style-loader')
+          rule.use('vue-style-loader').loader(require.resolve('vue-style-loader'))
         }
       }
 
       rule.use('css-loader')
-        .loader('css-loader')
+        .loader(require.resolve('css-loader'))
         .options(Object.assign({
           modules,
           exportOnlyLocals: isServer,
@@ -295,7 +295,7 @@ module.exports = (app, { isProd, isServer }) => {
         }, css))
 
       rule.use('postcss-loader')
-        .loader('postcss-loader')
+        .loader(require.resolve('postcss-loader'))
         .options(Object.assign({
           sourceMap: !isProd
         }, postcss, {

--- a/gridsome/lib/webpack/modules/assets.js
+++ b/gridsome/lib/webpack/modules/assets.js
@@ -34,7 +34,7 @@ function transformAttrValue(node, attr) {
 
   if (!isUrl(value) && !isMailtoLink(value) && !isTelLink(value) && isRelative(value)) {
     const query = createOptionsQuery(node.attrs)
-    result = `require("!!assets-loader?${query}!${value}")`
+    result = `require("!!${require.resolve('../loaders/assets-loader.js').replace(/\\/g, '/')}?${query}!${value}")`
   }
 
   return result

--- a/gridsome/lib/webpack/plugins/corejsBabelPlugin.js
+++ b/gridsome/lib/webpack/plugins/corejsBabelPlugin.js
@@ -1,0 +1,13 @@
+const corejsPath = require('path').dirname(require.resolve('core-js/package.json')).replace(/\\/g, '/')
+
+module.exports = () => ({
+  visitor: {
+    ImportDeclaration(path) {
+      if (path.node.specifiers.length !== 0 || path.node.source.value.indexOf('core-js/') !== 0) {
+        return
+      }
+
+      path.node.source.value = corejsPath + path.node.source.value.substr('core-js'.length)
+    },
+  },
+})

--- a/gridsome/lib/webpack/plugins/corejsBabelPlugin.js
+++ b/gridsome/lib/webpack/plugins/corejsBabelPlugin.js
@@ -8,6 +8,6 @@ module.exports = () => ({
       }
 
       path.node.source.value = corejsPath + path.node.source.value.substr('core-js'.length)
-    },
-  },
+    }
+  }
 })

--- a/gridsome/package.json
+++ b/gridsome/package.json
@@ -103,6 +103,22 @@
     "webpack-merge": "^4.2.1",
     "yaml-loader": "^0.5.0"
   },
+  "peerDependencies": {
+    "less-loader": "*",
+    "sass-loader": "*",
+    "stylus-loader": "*"
+  },
+  "peerDependenciesMeta": {
+    "sass-loader": {
+      "optional": true
+    },
+    "less-loader": {
+      "optional": true
+    },
+    "stylus-loader": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=8.3"
   },

--- a/gridsome/package.json
+++ b/gridsome/package.json
@@ -83,6 +83,7 @@
     "portfinder": "^1.0.20",
     "postcss-loader": "^3.0.0",
     "probe-image-size": "^4.0.0",
+    "resolve-from": "^5.0.0",
     "sharp": "^0.25.2",
     "slash": "^2.0.0",
     "sockjs": "^0.3.19",

--- a/gridsome/package.json
+++ b/gridsome/package.json
@@ -79,6 +79,7 @@
     "p-map": "^2.0.0",
     "path-to-regexp": "^2.2.1",
     "physical-cpu-count": "^2.0.0",
+    "pnp-webpack-plugin": "^1.6.4",
     "portfinder": "^1.0.20",
     "postcss-loader": "^3.0.0",
     "probe-image-size": "^4.0.0",

--- a/gridsome/package.json
+++ b/gridsome/package.json
@@ -94,6 +94,7 @@
     "vue-meta": "^2.2.2",
     "vue-router": "^3.1.3",
     "vue-server-renderer": "^2.6.10",
+    "vue-style-loader": "^4.1.2",
     "vue-template-compiler": "^2.6.10",
     "webpack": "^4.29.3",
     "webpack-chain": "^5.2.0",

--- a/packages/cli/lib/utils/index.js
+++ b/packages/cli/lib/utils/index.js
@@ -4,7 +4,7 @@ const semver = require('semver')
 exports.hasYarn = async function () {
   try {
     const { stdout: version } = await execa('yarn', ['--version'])
-    return semver.satisfies(version, '>= 1.4.0')
+    return semver.satisfies(version, '>= 1.4.0', { includePrerelease: true })
   } catch (err) {}
   return false
 }

--- a/packages/source-graphql/package.json
+++ b/packages/source-graphql/package.json
@@ -14,11 +14,11 @@
     "apollo-link-context": "^1.0.17",
     "apollo-link-http": "^1.5.14",
     "graphql-tools": "^4.0.4",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.0",
+    "graphql": "^14.4.2"
   },
   "peerDependencies": {
-    "gridsome": "0.x",
-    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+    "gridsome": "0.x"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/source-graphql/package.json
+++ b/packages/source-graphql/package.json
@@ -17,7 +17,8 @@
     "node-fetch": "^2.6.0"
   },
   "peerDependencies": {
-    "gridsome": "0.x"
+    "gridsome": "0.x",
+    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vue-remark/index.js
+++ b/packages/vue-remark/index.js
@@ -49,7 +49,7 @@ const createCustomBlockRule = (config, type) => {
   config.module.rule(type)
     .resourceQuery(re)
     .use('babel-loader')
-    .loader('babel-loader')
+    .loader(require.resolve('babel-loader'))
     .options({
       presets: [
         require.resolve('@babel/preset-env')
@@ -277,7 +277,7 @@ class VueRemark {
       })
       .end()
       .use('vue-loader')
-      .loader('vue-loader')
+      .loader(require.resolve('vue-loader'))
       .options(vueLoader.toConfig().options)
       .end()
       .use('vue-remark-loader')

--- a/packages/vue-remark/package.json
+++ b/packages/vue-remark/package.json
@@ -18,6 +18,7 @@
     "@babel/traverse": "^7.0.0",
     "@gridsome/source-filesystem": "^0.6.2",
     "@gridsome/transformer-remark": "^0.6.4",
+    "babel-loader": "8.0.5",
     "hash-sum": "^1.0.2",
     "hast-util-to-html": "^5.0.0",
     "he": "^1.2.0",
@@ -31,7 +32,8 @@
     "moment": "^2.24.0",
     "path-to-regexp": "^3.1.0",
     "unist-builder": "^1.0.3",
-    "unist-util-visit": "^1.4.0"
+    "unist-util-visit": "^1.4.0",
+    "vue-loader": "^15.7.1"
   },
   "peerDependencies": {
     "gridsome": "0.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15085,7 +15085,7 @@ vue-server-renderer@^2.6.10:
     serialize-javascript "^3.1.0"
     source-map "0.5.6"
 
-vue-style-loader@^4.1.0:
+vue-style-loader@^4.1.0, vue-style-loader@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/vue-style-loader/-/vue-style-loader-4.1.2.tgz#dedf349806f25ceb4e64f3ad7c0a44fba735fcf8"
   integrity sha512-0ip8ge6Gzz/Bk0iHovU9XAUQaFt/G2B61bnWa2tCcqqdgfHs1lF9xXorFbE55Gmy92okFT+8bfmySuUOu13vxQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -11540,6 +11540,13 @@ pngquant-bin@^5.0.0:
     execa "^0.10.0"
     logalot "^2.0.0"
 
+pnp-webpack-plugin@^1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz#c9711ac4dc48a685dabafc86f8b6dd9f8df84149"
+  integrity sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
+  dependencies:
+    ts-pnp "^1.1.6"
+
 portfinder@^1.0.20:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
@@ -14422,6 +14429,11 @@ ts-invariant@^0.4.0:
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
   dependencies:
     tslib "^1.9.3"
+
+ts-pnp@^1.1.6:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
+  integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12879,6 +12879,11 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
+resolve-from@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
+  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"


### PR DESCRIPTION
**What's the problem this PR addresses?**

- Gridsome doesn't work with [Yarn PnP](https://yarnpkg.com/features/pnp).
- Gridsome is passing loaders to webpack using their name instead of absolute path
- Gridsome has some undeclared dependencies

Fixes https://github.com/gridsome/gridsome/issues/551 (cc @Js-Brecht)
Closes https://github.com/yarnpkg/berry/issues/1266 (cc @borisdiakur)

**How did you fix it?**

- Use `require.resolve` for webpack loaders (https://github.com/yarnpkg/berry/tree/eff8ffd607242d80adbeaa05ebf5453a68dd299b/packages/yarnpkg-doctor#no-unqualified-webpack-config)
- Add undeclared dependencies (https://github.com/yarnpkg/berry/tree/eff8ffd607242d80adbeaa05ebf5453a68dd299b/packages/yarnpkg-doctor#no-unlisted-dependencies)
- Resolve user defined plugins relative to the context (gridsome.config.js)
- Add https://github.com/arcanis/pnp-webpack-plugin (the only PnP specific thing in this PR)
- Added an E2E test to make sure all dependencies are declared and required correctly