### PR TITLE
fix(source-contentful) add possibility to define search parameters in config

### DIFF
--- a/packages/source-contentful/index.js
+++ b/packages/source-contentful/index.js
@@ -111,7 +111,7 @@ class ContentfulSource {
   }
 
   async fetch (method, limit = 1000, order = 'sys.createdAt', parameters = {}) {
-    const fetch = skip => this.client[method]({ skip, limit, order, ...parameters })
+    const fetch = skip => this.client[method]({ ...parameters, skip, limit, order })
     const { total, items } = await fetch(0)
     const pages = Math.ceil(total / limit)
 

--- a/packages/source-contentful/index.js
+++ b/packages/source-contentful/index.js
@@ -11,7 +11,8 @@ class ContentfulSource {
       host: 'cdn.contentful.com',
       typeName: 'Contentful',
       richText: {},
-      routes: {}
+      routes: {},
+      parameters: {}
     }
   }
 
@@ -70,7 +71,8 @@ class ContentfulSource {
   }
 
   async getEntries (actions) {
-    const entries = await this.fetch('getEntries')
+    const parameters = this.options.parameters
+    const entries = await this.fetch('getEntries', 1000, 'sys.createdAt', parameters)
 
     for (const entry of entries) {
       const typeId = entry.sys.contentType.sys.id
@@ -108,8 +110,8 @@ class ContentfulSource {
     }
   }
 
-  async fetch (method, limit = 1000, order = 'sys.createdAt') {
-    const fetch = skip => this.client[method]({ skip, limit, order })
+  async fetch (method, limit = 1000, order = 'sys.createdAt', parameters = {}) {
+    const fetch = skip => this.client[method]({ skip, limit, order, ...parameters })
     const { total, items } = await fetch(0)
     const pages = Math.ceil(total / limit)
 

--- a/packages/source-contentful/package.json
+++ b/packages/source-contentful/package.json
@@ -1,9 +1,9 @@
 {
   "version": "0.5.3",
-  "name": "@gridsome/source-contentful",
+  "name": "@helloiamlukas/source-contentful",
   "description": "Contentful source for Gridsome",
-  "homepage": "https://github.com/gridsome/gridsome/tree/master/packages/source-contentful#readme",
-  "repository": "https://github.com/gridsome/gridsome/tree/master/packages/source-contentful",
+  "homepage": "https://github.com/helloiamlukas/gridsome/tree/master/packages/source-contentful#readme",
+  "repository": "https://github.com/helloiamlukas/gridsome/tree/master/packages/source-contentful",
   "main": "index.js",
   "keywords": [
     "gridsome",

--- a/packages/source-contentful/package.json
+++ b/packages/source-contentful/package.json
@@ -1,9 +1,9 @@
 {
   "version": "0.5.3",
-  "name": "@helloiamlukas/source-contentful",
+  "name": "@gridsome/source-contentful",
   "description": "Contentful source for Gridsome",
-  "homepage": "https://github.com/helloiamlukas/gridsome/tree/master/packages/source-contentful#readme",
-  "repository": "https://github.com/helloiamlukas/gridsome/tree/master/packages/source-contentful",
+  "homepage": "https://github.com/gridsome/gridsome/tree/master/packages/source-contentful#readme",
+  "repository": "https://github.com/gridsome/gridsome/tree/master/packages/source-contentful",
   "main": "index.js",
   "keywords": [
     "gridsome",


### PR DESCRIPTION
This will solve #748 

Previously the Contentful source only returned the default locale of a field. As [mentioned in the Contentful docs](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/localization), the search parameter `locale=*` has to be provided to return all locales of a field. 

With the changes in this pull request, you can now define search parameters in the plugin configuration. 

```
{
   use: '@gridsome/source-contentful',
   options: {
      space: process.env.CTF_SPACE_ID,
      accessToken: process.env.CTF_ACCESS_TOKEN,
      host: 'cdn.contentful.com',
      environment: 'master',
      typeName: 'Contentful',
      parameters: {
         locale: '*'
      }
   }
}
```