### PR TITLE
feat(source-contentful) multi-language support

### DIFF
--- a/packages/source-contentful/README.md
+++ b/packages/source-contentful/README.md
@@ -174,3 +174,114 @@ query Json {
   }
 }
 ```
+
+## Multi-language support
+
+To enable multi-language support you have to define your locales in the plugin configuration. The locales have to be the same as they are set up in the Contentful dashboard.
+
+```js
+module.exports = {
+  plugins: [
+    {
+      use: '@gridsome/source-contentful',
+      options: {
+        space: 'YOUR_SPACE', // required
+        accessToken: 'YOUR_ACCESS_TOKEN', // required
+        host: 'cdn.contentful.com',
+        environment: 'master',
+        typeName: 'Contentful',
+        locales: ['en', 'de']
+      }
+    }
+  ]
+}
+```
+
+Make sure you also include the locale in the template path of the Gridsome configuration. For more information regarding the template configuration, please check the [Gridsome documentation](https://gridsome.org/docs/templates/#setup-templates).
+
+```js
+module.exports = {
+  templates: {
+    ContentfulNews: [
+      {
+        path: (node) =>  `/${node.locale}/${node.locale === 'de' ? 'nachrichten' : 'news'}/${node.slug}`
+      }
+    ]
+  }
+}
+```
+
+### Usage in templates
+
+You can access the node like you are used to. The current locale is available within GraphQL schema in the `locale` field.
+
+```vue
+<template>
+  <Layout>
+    <!-- locale: {{ locale }} -->
+    <h1>{{ $page.news.title }}</h1>
+  </Layout>
+</template>
+
+<page-query>
+    query News($path: String!) {
+      news: contentfulNews(path: $path) {
+        title,
+        locale
+      }
+    }
+</page-query>
+```
+
+### Usage in pages
+
+When querying nodes within a page, you have to filter for the requested locale. 
+
+```vue
+<template>
+  <Layout>
+    <div v-for="edge in $page.news.edges" :key="edge.node.id">
+      {{ edge.node.title }}
+    </div>
+  </Layout>
+</template>
+
+<page-query>
+    query News {
+      news: allContentfulNews(filter: { locale: { eq: "en" } }) {
+        edges {
+          node {
+            id
+            title
+          }
+        }
+      }
+    }
+</page-query>
+```
+It is recommended to use this in combination with [gridsome-plugin-i18n](https://github.com/daaru00/gridsome-plugin-i18n). Please refer to [their documentation](https://github.com/daaru00/gridsome-plugin-i18n#gridsome-i18n-plugin) for a complete setup guide.
+
+After the successful installation you can access `$locale` from the page context and use it as a query variable. E.g.:
+
+```vue
+<template>
+  <Layout>
+    <div v-for="edge in $page.news.edges" :key="edge.node.id">
+      {{ edge.node.title }}
+    </div>
+  </Layout>
+</template>
+
+<page-query>
+    query News($locale: String!) {
+      news: allContentfulNews(filter: { locale: { eq: $locale } }) {
+        edges {
+          node {
+            id
+            title
+          }
+        }
+      }
+    }
+</page-query>
+```

--- a/packages/source-contentful/index.js
+++ b/packages/source-contentful/index.js
@@ -12,7 +12,8 @@ class ContentfulSource {
       typeName: 'Contentful',
       richText: {},
       routes: {},
-      parameters: {}
+      parameters: {},
+      locales: [undefined]
     }
   }
 
@@ -72,7 +73,12 @@ class ContentfulSource {
 
   async getEntries (actions) {
     const parameters = this.options.parameters
-    const entries = await this.fetch('getEntries', 1000, 'sys.createdAt', parameters)
+    const locales = this.options.locales
+    const entries = []
+
+    for (const locale of locales) {
+      entries.push(...await this.fetch('getEntries', 1000, 'sys.createdAt', locale ? {...parameters, locale}: parameters))
+    }
 
     for (const entry of entries) {
       const typeId = entry.sys.contentType.sys.id
@@ -104,9 +110,14 @@ class ContentfulSource {
         }
       }
 
-      node.id = entry.sys.id
 
-      collection.addNode(node)
+      if (node.locale === undefined) {
+        node.id = entry.sys.id
+        collection.addNode(node)
+        return
+      }
+
+      collection.addNode(node, [entry.sys.id, node.locale])
     }
   }
 


### PR DESCRIPTION
This pull request adds **proper multi-language support** for the Contentful source.

### Before
I previously opened a pull request to define search parameters in the plugin configuration (#1331). This was mainly used to add the `locale` search parameter, in order to retrieve localized nodes. 

```js
{
   use: "@gridsome/source-contentful",
   options: {
      space: process.env.CTF_SPACE_ID,
      accessToken: process.env.CTF_ACCESS_TOKEN,
      host: "cdn.contentful.com",
      environment: "master",
      typeName: "Contentful",
      parameters: {
         locale: "*"
      }
   }
}
```

Unfortunately the structure of the returned nodes is not so straight forward to work with. A query within a template would look like this:

```graphql
query News($path: String!) {
  news: contentfulNews(path: $path) {
    title {
       en, de
    }
  }
}
```

If you have a lot of fields, the need for the localized subfields adds up and your query will end up in a huge repetitive mess. In addition to that, **you can't define localized template paths, as `node.locale` is always undefined**. 


### Now

This pull request fixes the problems mentioned above (and is also a proper solution for #748). You can now define your locales in the source directly:

```js
{
   use: '@gridsome/source-contentful',
   options: {
     space: 'YOUR_SPACE', // required
     accessToken: 'YOUR_ACCESS_TOKEN', // required
     host: 'cdn.contentful.com',
     environment: 'master',
     typeName: 'Contentful',
     locales: ['en', 'de']
   }
}
```

This will import your nodes once per defined locale. Due to this, it is possible to define localized template paths in the Gridsome configuration.

```js
module.exports = {
  templates: {
    ContentfulNews: [
      {
        path: (node) =>  `/${node.locale}/${node.locale === 'de' ? 'nachrichten' : 'news'}/${node.slug}`
      }
    ]
  }
}
```

The query within a template is the same, as it would be in a single language application. In addition to that, the `locale` field returns the current locale.


```graphql
query News($path: String!) {
   news: contentfulNews(path: $path) {
      title,
      locale
   }
}
```