### PR TITLE
Add custom class prefix to remark-prismjs

### DIFF
--- a/packages/remark-prismjs/README.md
+++ b/packages/remark-prismjs/README.md
@@ -62,6 +62,14 @@ module.exports = {
 
 ## Options
 
+#### customClassPrefix
+
+- Type: `String`
+- Default: `''`
+
+If Prism's default classes are too generic and cause conflicts, you can add a prefix like `"prism--"` to all Prism
+classes by passing it in as the `customClassPrefix`. 
+
 #### transformInlineCode
 
 - Type: `Boolean`

--- a/packages/remark-prismjs/index.js
+++ b/packages/remark-prismjs/index.js
@@ -1,6 +1,6 @@
 const h = require('hastscript')
 const Prism = require('prismjs')
-require('prismjs/plugins/custom-class/prism-custom-class');
+require('prismjs/plugins/custom-class/prism-custom-class')
 const u = require('unist-builder')
 const escapeHtml = require('escape-html')
 const visit = require('unist-util-visit')
@@ -13,7 +13,7 @@ require('prismjs/components/index')()
 
 module.exports = (
   {
-    customClassPrefix = "",
+    customClassPrefix = '',
     transformInlineCode = false,
     showLineNumbers: showLineNumbersGlobal = false
   } = {}

--- a/packages/remark-prismjs/index.js
+++ b/packages/remark-prismjs/index.js
@@ -1,5 +1,6 @@
 const h = require('hastscript')
 const Prism = require('prismjs')
+require('prismjs/plugins/custom-class/prism-custom-class');
 const u = require('unist-builder')
 const escapeHtml = require('escape-html')
 const visit = require('unist-util-visit')
@@ -12,10 +13,13 @@ require('prismjs/components/index')()
 
 module.exports = (
   {
+    customClassPrefix = "",
     transformInlineCode = false,
     showLineNumbers: showLineNumbersGlobal = false
   } = {}
 ) => tree => {
+  Prism.plugins.customClass.prefix(customClassPrefix)
+
   visit(tree, 'code', (node, index, parent) => {
     parent.children.splice(index, 1, createCode(node, showLineNumbersGlobal))
   })


### PR DESCRIPTION
Prismjs's default classes for syntax highlighting can come into conflict with your own classes. Adding this plugin from prismjs lets us prefix its classnames so that we can avoid this. 

Before:
![Screenshot 2020-09-21 235321](https://user-images.githubusercontent.com/12194331/93852227-8404eb00-fc66-11ea-857a-8b5639f3a9c7.png)

After:
![Screenshot 2020-09-21 235418](https://user-images.githubusercontent.com/12194331/93852236-88310880-fc66-11ea-89f1-148d4185582d.png)

I've ran into this issue myself and you can see examples of this causing issues even in Gridsome starters like [this one](https://calebanthony.github.io/gridsome-bulma/say-hello-to-gridsome). Notice how the code block looks weird, with anomalies like the giant number 5? That's from the conflicting number class from Bulma and number in Prismjs. I wonder if there should even be a prefix by default, if this really is so common, but I have implemented this as an option.