### PR TITLE
docs: Fix simple typo, guillements -> guillemets

### DIFF
--- a/packages/transformer-remark/README.md
+++ b/packages/transformer-remark/README.md
@@ -138,7 +138,7 @@ Automatically add links to headings. Disabled if `slug` is `false`.
 - Type: `boolean`
 - Default: `true`
 
-Support ASCII guillements (`<<`, `>>`) and mapping them to HTML.
+Support ASCII guillemets (`<<`, `>>`) and mapping them to HTML.
 
 #### imageQuality
 


### PR DESCRIPTION
There is a small typo in packages/transformer-remark/README.md.

Should read `guillemets` rather than `guillements`.

