### PR TITLE
Add option to authenticate with wordpress using JWT

### DIFF
--- a/packages/source-wordpress/README.md
+++ b/packages/source-wordpress/README.md
@@ -100,3 +100,25 @@ If you are trying to query posts, you will need to add the `normalize: true` opt
         },
     ]
 ```
+
+## Authentication
+
+### JSON Web Token
+
+If you add a `jwtAuth` object to the options, the plugin will first authenticate with the username and password provided. All data fetched afterwards will use the JWT in the header.
+
+1. Install and activate a JWT wordpress plugin (tested with `https://github.com/usefulteam/jwt-auth`) 
+2. Add the following fields to gridsome.config.js
+
+```js
+  use: '@gridsome/source-wordpress',
+  options: {
+    ... // other source-wordpress options
+    jwtAuth: {
+      route: 'jwt-auth/v1/token',
+      username: process.env.WP_BUILD_USER,
+      password: process.env.WP_BUILD_PW
+	},
+  }
+```
+

--- a/packages/source-wordpress/index.js
+++ b/packages/source-wordpress/index.js
@@ -185,7 +185,7 @@ class WordPressSource {
 
   async fetch (method, url, params = {}, fallbackData = [], data = {}) {
     let res
-     
+
     try {
       res = await this.client.request({ method, url, params, data })
     } catch ({ response, code, config }) {
@@ -318,15 +318,14 @@ class WordPressSource {
     )
   }
 
-  async authenticateWithJwt() {
+  async authenticateWithJwt () {
     console.log('Attempting authentication with wordpress...')
     const jwtRespnse = await this.getJwtToken()
     if (jwtRespnse.success) {
       const token = jwtRespnse.data.token
       console.log('JWT received, adding to headers')
       this.client.defaults.headers.common['Authorization'] = `Bearer ${token}`
-    }
-    else {
+    } else {
       throw new Error(
         `Failed to authenticate.\n` +
         `Error Code: ${jwtRespnse.code}\n` +


### PR DESCRIPTION
I needed to add a form of authentication for a large project, one that could be used across multiple areas to avoid implementing 2 or 3 different forms of auth for different components (pulling data from wp, gravity forms plugin, client authentication on frontend).

Open to any suggestions. It would be cool to see this feature in gridsome though without needing to maintain a fork of the project or the source-wordpress plug.
