### PR TITLE
fix: sockjs when no connection `null` argument

### DIFF
--- a/gridsome/lib/server/Server.js
+++ b/gridsome/lib/server/Server.js
@@ -105,6 +105,7 @@ class Server {
       const echo = sockjs.createServer({ log: () => null })
 
       echo.on('connection', connection => {
+        if(!connection) return
         this._app.clients[connection.id] = connection
 
         connection.on('close', () => {


### PR DESCRIPTION
 - This appears to fix a hard to figure out bug.
 - Sometimes the `sockjs` 'connection' event would be called with `null` argument,
   which would crash `gridsome develop`.
 - I have not been able to debug it any further, or come up with a test which proves that
   the issue is now fixed.
 - There is a related bug from Sockjs-node: https://github.com/sockjs/sockjs-node/issues/121
 - The error that used to appear always appeared like the following:

 ```
   Site running at:
   - Local:                 http://localhost:8080/
   - Network:               http://192.168.1.134:8080/

   Explore GraphQL data at: http://localhost:8080/___explore

 /Users/myuser/work/playground/mysite/gridsome-site/node_modules/gridsome/lib/server/Server.js:110
         this._app.clients[connection.id] = connection
                                      ^

 TypeError: Cannot read property 'id' of null
     at Server.<anonymous> (/Users/myuser/work/playground/mysite/gridsome-site/node_modules/gridsome/lib/server/Server.js:110:38)
     at Server.emit (events.js:210:5)
     at App.emit (/Users/myuser/work/playground/mysite/gridsome-site/node_modules/sockjs/lib/sockjs.js:196:29)
     at /Users/myuser/work/playground/mysite/gridsome-site/node_modules/sockjs/lib/transport.js:111:25
     at processTicksAndRejections (internal/process/task_queues.js:75:11)
```

I have a Gridsome installation with tons of markdown files. It will happen approx 50% of the times I run `gridsome develop`.

I am happy if this PR is just closed as I realise this isn't a great PR, there are no tests and no way to prove that this actually fixed
anything. But since I have had this change in place, `gridsome develop` doesn't crash and I can use it without errors.

If anything I hope that this will appear on Google and it might lead others to a nicer solution.