### PR TITLE
fix(source-wordpress): non-paginated request on users endpoint causing truncated data

### DIFF
--- a/packages/source-wordpress/index.js
+++ b/packages/source-wordpress/index.js
@@ -69,7 +69,7 @@ class WordPressSource {
   }
 
   async getUsers (actions) {
-    const { data } = await this.fetch('wp/v2/users')
+    const data = await this.fetchPaged('wp/v2/users')
     const addCollection = actions.addCollection || actions.addContentType
 
     const authors = addCollection({


### PR DESCRIPTION
The users endpoint of wp-json api by default provides 10 users (or authors).
Since the previous version was using a request without pagination some posts
could get null author fields causing problems in template building.

This small change turns them into paged requests like some other types are already
doing.