### PR TITLE
#1424 Validate template name - don't allow reserved names

### DIFF
--- a/gridsome/lib/plugins/TemplatesPlugin.js
+++ b/gridsome/lib/plugins/TemplatesPlugin.js
@@ -7,6 +7,7 @@ const moment = require('moment')
 const chokidar = require('chokidar')
 const pathToRegexp = require('path-to-regexp')
 const { deprecate } = require('../utils/deprecate')
+const { validateTypeName } = require('../graphql/utils')
 const { ISO_8601_FORMAT } = require('../utils/constants')
 const { isPlainObject, trimStart, trimEnd, get, memoize } = require('lodash')
 
@@ -132,6 +133,7 @@ const setupTemplates = ({ context, templates, permalinks }) => {
   }
 
   for (const typeName in templates) {
+    validateTypeName(typeName)
     templates[typeName].forEach(options => {
       if (!isDev && !isUnitTest && !fs.existsSync(options.component)) {
         const relPath = path.relative(context, options.component)


### PR DESCRIPTION
Closes #1424 

```
Error: 'Page' is a reserved type name.
    at exports.validateTypeName (/home/manu/stuff/gridsome/gridsome/lib/graphql/utils.js:30:11)
    at setupTemplates (/home/manu/stuff/gridsome/gridsome/lib/plugins/TemplatesPlugin.js:136:5)
    at new TemplatesPlugin (/home/manu/stuff/gridsome/gridsome/lib/plugins/TemplatesPlugin.js:161:23)
    at Plugins.initialize (/home/manu/stuff/gridsome/gridsome/lib/app/Plugins.js:61:11)
    at App.init (/home/manu/stuff/gridsome/gridsome/lib/app/App.js:128:18)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async App.bootstrap (/home/manu/stuff/gridsome/gridsome/lib/app/App.js:49:5)
    at async module.exports (/home/manu/stuff/gridsome/gridsome/lib/app/index.js:12:3)
    at async module.exports (/home/manu/stuff/gridsome/gridsome/lib/develop.js:46:15)
error Command failed with exit code 1.
```