### PR TITLE
feat(pager): showLinks option show only prev/next links(#215)

### DIFF
--- a/gridsome/app/components/Pager.js
+++ b/gridsome/app/components/Pager.js
@@ -78,7 +78,8 @@ export default {
       if (end < total) links.push(renderLink(total, lastLabel, ariaLastLabel, [lastClass, navClass]))
     }
 
-    if (links.length < 2) return null
+    if (showLinks && links.length < 2) return null
+    if (!showLinks && links.length === 0) return null
 
     return h('nav', {
       ...data,


### PR DESCRIPTION
Close #215
I wanted to use this option(#215), so I fixed it.

## Example

Pager component like this.

Option → `:showLinks="false"`

```vue
<Pager :info="$page.myobject.pageInfo" :showLinks="false"/>
```

## Result

See only next/prev links in pagination (numeric page links removed).