### PR TITLE
Add database formatted DateTime to GraphQL

### DIFF
--- a/gridsome/lib/graphql/types/date.js
+++ b/gridsome/lib/graphql/types/date.js
@@ -1,9 +1,9 @@
 const moment = require('moment')
 const { Kind } = require('graphql')
-const { ISO_8601_FORMAT } = require('../../utils/constants')
+const { SUPPORTED_DATE_FORMATS } = require('../../utils/constants')
 
 exports.isDate = value => {
-  const date = moment.utc(value, ISO_8601_FORMAT, true)
+  const date = moment.utc(value, SUPPORTED_DATE_FORMATS, true)
   return date.isValid() && typeof value !== 'number'
 }
 
@@ -34,7 +34,7 @@ function formatDate (value, args = {}) {
     const { format, locale = 'en' } = args
 
     return moment
-      .utc(toString(value), ISO_8601_FORMAT, true)
+      .utc(toString(value), SUPPORTED_DATE_FORMATS, true)
       .locale(locale)
       .format(format)
   }

--- a/gridsome/lib/plugins/TemplatesPlugin.js
+++ b/gridsome/lib/plugins/TemplatesPlugin.js
@@ -8,7 +8,7 @@ const chokidar = require('chokidar')
 const pathToRegexp = require('path-to-regexp')
 const { deprecate } = require('../utils/deprecate')
 const { validateTypeName } = require('../graphql/utils')
-const { ISO_8601_FORMAT } = require('../utils/constants')
+const { SUPPORTED_DATE_FORMATS } = require('../utils/constants')
 const { isPlainObject, trimStart, trimEnd, get, memoize } = require('lodash')
 
 const isDev = process.env.NODE_ENV === 'development'
@@ -21,7 +21,7 @@ const makeId = (uid, name) => {
 }
 
 const makePath = (object, { path, routeKeys, createPath }, dateField = 'date', slugify) => {
-  const date = memoize(() => moment.utc(object[dateField], ISO_8601_FORMAT, true))
+  const date = memoize(() => moment.utc(object[dateField], SUPPORTED_DATE_FORMATS, true))
   const length = routeKeys.length
   const params = {}
 

--- a/gridsome/lib/utils/constants.js
+++ b/gridsome/lib/utils/constants.js
@@ -23,7 +23,8 @@ module.exports = {
   SORT_ORDER: 'DESC',
   PER_PAGE: 25,
 
-  ISO_8601_FORMAT: [
+  SUPPORTED_DATE_FORMATS: [
+    // ISO8601
     'YYYY',
     'YYYY-MM',
     'YYYY-MM-DD',
@@ -52,7 +53,13 @@ module.exports = {
     'YYYY-[W]WW-E',
     'YYYY[W]WWE',
     'YYYY-DDDD',
-    'YYYYDDDD'
+    'YYYYDDDD',
+
+    'YYYY-MM-DD HH:mm:ss Z',
+    'YYYY-MM-DD HH:mm:ss',
+
+    'YYYY-MM-DD HH:mm:ss.SSSS Z',
+    'YYYY-MM-DD HH:mm:ss.SSSS'
   ]
 }
 

--- a/packages/vue-remark/lib/utils.js
+++ b/packages/vue-remark/lib/utils.js
@@ -2,7 +2,7 @@ const path = require('path')
 const moment = require('moment')
 const { isPlainObject, get } = require('lodash')
 
-const ISO_8601_FORMAT = [
+const SUPPORTED_DATE_FORMATS = [
   'YYYY',
   'YYYY-MM',
   'YYYY-MM-DD',
@@ -31,7 +31,13 @@ const ISO_8601_FORMAT = [
   'YYYY-[W]WW-E',
   'YYYY[W]WWE',
   'YYYY-DDDD',
-  'YYYYDDDD'
+  'YYYYDDDD',
+
+  'YYYY-MM-DD HH:mm:ss Z',
+  'YYYY-MM-DD HH:mm:ss',
+
+  'YYYY-MM-DD HH:mm:ss.SSSS Z',
+  'YYYY-MM-DD HH:mm:ss.SSSS'
 ]
 
 exports.createFile = function (options) {
@@ -88,7 +94,7 @@ exports.normalizeLayout = function (layout) {
 }
 
 exports.makePathParams = (object, { routeKeys, dateField = 'date' }, slugify) => {
-  const date = moment.utc(object[dateField], ISO_8601_FORMAT, true)
+  const date = moment.utc(object[dateField], SUPPORTED_DATE_FORMATS, true)
   const length = routeKeys.length
   const params = {}
 


### PR DESCRIPTION
Here I am adding support for Database formatted DateTime. 

Some of my imported data appear to be in this format and querying it via GraphQL yields an error, but `moment.js` can successfully parse the format. 

I hope this subtle change helps other projects facing the same Date type issue. 

example:

```
2011-02-25 23:59:59.999 +0530
```