### PR TITLE
Fix to Update CSS Loader to ^5.1.2

### DIFF
--- a/gridsome/package.json
+++ b/gridsome/package.json
@@ -41,7 +41,7 @@
     "columnify": "^1.5.4",
     "connect-history-api-fallback": "^1.6.0",
     "core-js": "^3.6.4",
-    "css-loader": "^2.1.0",
+    "css-loader": "^5.1.0",
     "devcert": "^1.1.0",
     "dotenv": "^6.2.0",
     "enhanced-resolve": "4.1.1",


### PR DESCRIPTION
Updated CSS Loader to ^5.1.2 in order to suffice for other packages that require newer versions of this package