### PR TITLE
feat(source-contentful): added entry metadata

### DIFF
--- a/packages/source-contentful/index.js
+++ b/packages/source-contentful/index.js
@@ -105,7 +105,7 @@ class ContentfulSource {
       }
 
       node.id = entry.sys.id
-      node.metadata = entry.metadata;
+      node.metadata = entry.metadata
 
       collection.addNode(node)
     }

--- a/packages/source-contentful/index.js
+++ b/packages/source-contentful/index.js
@@ -105,6 +105,7 @@ class ContentfulSource {
       }
 
       node.id = entry.sys.id
+      node.metadata = entry.metadata;
 
       collection.addNode(node)
     }


### PR DESCRIPTION
This is a really simple one-line change to the source contentful plugin that will pull the in the `metadata` field which contains tags as part of Contentful's new [tagging feature](https://www.contentful.com/help/tags/). This allows you to tag assets to organise content, and we're using it to help determine what content should get built or ignored in staging/prod versus development.

![Screenshot 2021-04-09 at 11 00 27](https://user-images.githubusercontent.com/57626492/114164086-cf40cb80-9922-11eb-8e41-2e9e9551cc1d.png)

Here's a sample of what this looks like in GraphQL. 

![Screenshot 2021-04-09 at 11 33 53](https://user-images.githubusercontent.com/57626492/114167912-79baed80-9927-11eb-93c9-8dd671b36950.png)