### PR TITLE
Update favicon sizes as per Google Developer Recommendation

### DIFF
--- a/gridsome/lib/app/loadConfig.js
+++ b/gridsome/lib/app/loadConfig.js
@@ -526,7 +526,7 @@ function normalizeImages (config = {}) {
 function normalizeIconsConfig (config = {}) {
   const res = {}
 
-  const faviconSizes = [16, 32, 96]
+  const faviconSizes = [16, 32, 96, 192, 196]
   const touchiconSizes = [76, 152, 120, 167, 180]
   const defaultIcon = './src/favicon.png'
   const icon = typeof config === 'string' ? { favicon: config } : (config || {})


### PR DESCRIPTION
favicon sizes must contain 192 and 196 as `192x192` is Google Developer Web App Manifest Recommendation and `196x196` is Android home screen icon