### PR TITLE
fix(cli): support gridsome-starter-name syntax

### DIFF
--- a/packages/cli/lib/commands/create.js
+++ b/packages/cli/lib/commands/create.js
@@ -105,8 +105,16 @@ module.exports = async (name, starter = '') => {
   }
 
   if (starter) {
+    const officialTemplates = starters
+      // Official starter kit entries
+      .filter(({ author }) => author === 'gridsome')
+      // Extract the starter kit name
+      .map(({ repo }) => repo.split('-').pop())
+
     if (/^([a-z0-9_-]+)\//i.test(starter)) {
       starter = `https://github.com/${starter}.git`
+    } else if (officialTemplates.includes(starter)) {
+      starter = `https://github.com/gridsome/gridsome-starter-${starter}.git`
     }
   } else {
     starter = 'https://github.com/gridsome/gridsome-starter-default'


### PR DESCRIPTION
Currently, an attempt to create a new project with the official [starter-kit-name](https://github.com/gridsome/gridsome/tree/master/packages/cli#creating-new-projects) syntax fails.
```sh
$ gridsome create my-app wordpress

  Pick a package manager that will install dependencies npm
  Do you want to use npm for all future Gridsome projects? No

❯ Clone wordpress
❯ Install dependencies with npm
Error: Command failed: git clone wordpress  --single-branch
```

It seems to have changed in 549d487704e1811582d45e435010cb86a2530c75

This PR aims at restoring this behavior.