### PR TITLE
feat(drupal): handle path attribute in drupal's jsonapi response

### DIFF
--- a/packages/source-drupal/README.md
+++ b/packages/source-drupal/README.md
@@ -93,6 +93,7 @@ user--user -> DrupalUser
 
 > The `keys` above are the defaults, but can be changed using [JSON:API
 > Extras](https://www.drupal.org/project/jsonapi_extras) (i.e. `node--article` can become just `article`
+> Note: JSON:API can return an attribute `path` that contains an object. This `path` attribute conflicts with Gridsome's GraphQL `path` field. To avoid conflict the Drupal data contained in `path` has been renamed to `drupal_path`.
 
 The url `values` of the `links` object get looped over and requested via `axios` and each response becomes processed, converted into `nodes` on each respective GraphQL Type. Each entity response comes with a `relationship` object which is merged into each `node` - the Gridsome Core then intelligently creates all the GraphQL Connects. [See example page queries below](#example-page-queries).
 

--- a/packages/source-drupal/lib/Entity.js
+++ b/packages/source-drupal/lib/Entity.js
@@ -109,7 +109,8 @@ class Entity {
 
   processFields (fields = {}) {
     const processedFields = reduce(fields, (newFields, field, key) => {
-      newFields[key] = (field !== 'null') ? field : ''
+      const modifiedKey = (key !== 'path') ? key : 'drupal_' + key
+      newFields[modifiedKey] = (field !== 'null') ? field : ''
 
       return newFields
     }, {})


### PR DESCRIPTION
In Drupal's jsonapi response there is a `path` attribute, the value is an object with some attributes like `alias` see here: https://dev-campus-drupal-9.pantheonsite.io/jsonapi/node/article

When there are more then one article you see this when running `gridsome develop`:
```
DrupalNodePage > Failed to add node: Duplicate key for property path: [object Object]
DrupalNodePage > Failed to add node: Duplicate key for property path: [object Object]
DrupalNodeArticle > Failed to add node: Duplicate key for property path: [object Object]
```

Only one node for that type will ever get loaded into GraphQL. In the output above I should have 3 DrupalNodePages and 2 DrupalNodeArticle. But when I go into the GraphQL explorer I only have 1 of each type.

Evidence of error is apparent in #869 

They had a permission's error that killed the build all together, however there is evidence of the duplicate key error.

===

Edit:

@matt-e-king was kind enough to hop on a Zoom call with me and we ran some tests on the development environment I had setup. We determined that due to Gridsome and Drupal having conflicting uses for the `path` attribute it would be best to rename Drupal's `path` to `drupal_path` when pulling it into the Gridsome data layer. 