### PR TITLE
feat: afterSourcesLoaded hook

### DIFF
--- a/gridsome/lib/app/PluginAPI.js
+++ b/gridsome/lib/app/PluginAPI.js
@@ -49,6 +49,10 @@ class PluginAPI {
     this._on('loadSource', handler)
   }
 
+  afterSourcesLoaded(handler){
+    this._on('afterSourcesLoaded', handler)
+  }
+
   createSchema (handler) {
     this._on('createSchema', handler)
   }

--- a/gridsome/lib/app/PluginAPI.js
+++ b/gridsome/lib/app/PluginAPI.js
@@ -49,10 +49,6 @@ class PluginAPI {
     this._on('loadSource', handler)
   }
 
-  afterSourcesLoaded(handler){
-    this._on('afterSourcesLoaded', handler)
-  }
-
   createSchema (handler) {
     this._on('createSchema', handler)
   }

--- a/gridsome/lib/app/Plugins.js
+++ b/gridsome/lib/app/Plugins.js
@@ -26,8 +26,13 @@ class Plugins {
     )
 
     app.hooks.bootstrap.tapPromise(
-      { name: 'createSchema', label: 'Create GraphQL schema', phase: BOOTSTRAP_GRAPHQL },
-      () => this.createSchema()
+        {name: 'afterSourcesLoaded', label: 'After sources loaded', phase: BOOTSTRAP_SOURCES},
+        () => this.afterSourcesLoaded()
+    )
+
+    app.hooks.bootstrap.tapPromise(
+        {name: 'createSchema', label: 'Create GraphQL schema', phase: BOOTSTRAP_GRAPHQL},
+        () => this.createSchema()
     )
 
     app.hooks.bootstrap.tapPromise(

--- a/gridsome/lib/app/Plugins.js
+++ b/gridsome/lib/app/Plugins.js
@@ -86,10 +86,20 @@ class Plugins {
     })
   }
 
-  async createSchema() {
-    const results = await this.run('createSchema', api => {
-      return createSchemaActions(api, this._app)
-    })
+    /**
+     *
+     * @returns {Promise<[]|*[]>}
+     */
+    async afterSourcesLoaded() {
+        return this.run('afterSourcesLoaded', api => {
+            return createSchemaActions(api, this._app)
+        })
+    }
+
+    async createSchema() {
+        const results = await this.run('createSchema', api => {
+            return createSchemaActions(api, this._app)
+        })
 
     // add custom schemas returned from the hook handlers
     results.forEach(schema =>


### PR DESCRIPTION
What I was trying to achieve was connecting collection entries of two sources with each other, based on certain fields.

However, using the `getCollection` action in the `loadSources` hook for this case won´t work, as the collections from the source plugins aren´t loaded before, but afterwards and getCollection always returns 'undefined'.

To solve this, I´ve created a new hook, called `afterSourcesLoaded` which is called after all source plugins have fetched their data and created their corresponding collections. You can do manipulation on all available data (that is loaded with the data store api).

Although it is working as expected, I´m not sure if it´s done correctly. For example I´ve used the BOOTSTRAP_SOURCES phase twice, not sure if it has side effects in some way.

Also, the createSchemaActions(api, this._app) is called from loadSources and afterSourcesLoaded. Consequences if any?

