### PR TITLE
feat: create json data hash on route basis

### DIFF
--- a/gridsome/app/fetch.js
+++ b/gridsome/app/fetch.js
@@ -59,7 +59,7 @@ export default (route, options = {}) => {
 
   return new Promise((resolve, reject) => {
     const usePath = route.name === NOT_FOUND_NAME ? NOT_FOUND_PATH : route.path
-    const jsonPath = route.meta.dataPath || unslashEnd(usePath) + '/index.json'
+    const jsonPath = route.meta.dataPath || unslashEnd(usePath) + `/index.${route.meta.dataHash}.json`
     const absPath = unslashEnd(dataUrl) + jsonPath
 
     if (shouldPrefetch && !isLoaded[jsonPath]) {

--- a/gridsome/lib/app/build/createRenderQueue.js
+++ b/gridsome/lib/app/build/createRenderQueue.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const crypto = require('crypto')
 const { pathToFilePath } = require('../../pages/utils')
 const { trimEnd } = require('lodash')
 
@@ -72,7 +73,10 @@ function createRenderEntry (page, route, config, currentPage = 1) {
   }
 
   const htmlOutput = pathToFilePath(publicPath)
-  const dataOutput = pathToFilePath(publicPath, 'json')
+  const dataHash = route.internal.query.source
+    ? crypto.createHash('md5').update(route.internal.query.source).digest('hex').slice(0, 8)
+    : ''
+  const dataOutput = pathToFilePath(publicPath, 'json').replace('.json', `.${dataHash}.json`)
   const prettyPath = trimEnd(publicPath, '/') || '/'
 
   const location = route.type === 'dynamic'

--- a/gridsome/lib/app/codegen/routes.js
+++ b/gridsome/lib/app/codegen/routes.js
@@ -1,4 +1,5 @@
 const slash = require('slash')
+const crypto = require('crypto')
 const { relative } = require('path')
 const { slugify } = require('../../utils')
 const { pathToFilePath } = require('../../pages/utils')
@@ -24,7 +25,8 @@ function genRoutes(app) {
     type: route.type,
     component: isUnitTest
       ? relative(app.context, route.component)
-      : route.component
+      : route.component,
+    querySource: route.internal.query.source
   })
 
   for (const redirect of redirects) {
@@ -91,6 +93,11 @@ function genRoute (item) {
     const dataPath = pathToFilePath(item.path, 'json')
     metas.push(`dataPath: ${JSON.stringify(slash(dataPath))}`)
     metas.push(`dynamic: true`)
+  } else if (item.type == 'static') {
+    const dataHash = item.querySource
+      ? crypto.createHash('md5').update(item.querySource).digest('hex').slice(0, 8)
+      : ''
+    metas.push(`dataHash: ${JSON.stringify(dataHash)}`)
   } else if (item.name === NOT_FOUND_NAME) {
     metas.push(`dataPath: ${JSON.stringify('/404.json')}`)
   }


### PR DESCRIPTION
*This is a draft PR and proof of concept. Tests not passed and code not cleaned. And I want to have some disscussion.*

Create json data hash based on route query source. e.g.

```
data
├── 404.json
├── a-post-with-a-cover-image
│   └── index.4b9dd3d1.json
├── index.e463b400.json
├── markdown-test-file
│   └── index.4b9dd3d1.json
├── say-hello-to-gridsome
│   └── index.4b9dd3d1.json
└── tag
    ├── Cover Image
    │   └── index.def7a3cd.json
    ├── Markdown
    │   └── index.def7a3cd.json
    ├── Releases
    │   └── index.def7a3cd.json
    └── Test files
        └── index.def7a3cd.json
```

Benifits:
- Keep data versioned by their structure
- Thus avoid most incapability issue when browser caches old data file
- In PWA, keeping old json data allows old version work properly before upgrade

This change tries to replace the hash generated by webpack, because currently
- This hash is somewhat inconsistent
- One single data change causing all html and json changing
- Thus makes incremental build impossible

Generating hashes per page, although it solves drawbacks of using webpack hash and has benifit of hashing route query, requires a large table to look up, which is impractical with large sites.

I think this feature should be controled by an option. It is suggested to work without hash-meta and hash in json data, but turning `cacheBusting` off has a side effect of js and css hashing. How to design the options?
