### PR TITLE
Add extra options

### DIFF
--- a/packages/source-filesystem/README.md
+++ b/packages/source-filesystem/README.md
@@ -119,3 +119,11 @@ module.exports = {
 - Default: `['index']`
 
 Define which files to consider as index files. These files will not have their filename appear in its route path and will become the main `index.html` file of the directory. Make sure there is only one possible index file per directory if multiple index names are defined. This option is only used if there is no dynamic `route` defined.
+
+#### nodeExtraOptions
+
+- Type: `Object`
+- Default: `{}`
+
+Define extra options that will be added to every node in the collection.
+Can be useful, for example, to import files from different folders and add a type option value or a tag.

--- a/packages/source-filesystem/index.js
+++ b/packages/source-filesystem/index.js
@@ -16,7 +16,8 @@ class FilesystemSource {
       pathPrefix: undefined,
       index: ['index'],
       typeName: 'FileNode',
-      refs: {}
+      refs: {},
+      nodeExtraOptions: {}
     }
   }
 
@@ -64,7 +65,7 @@ class FilesystemSource {
 
     await Promise.all(files.map(async file => {
       const options = await this.createNodeOptions(file, actions)
-      const node = this.collection.addNode(options)
+      const node = this.collection.addNode({ ...this.options.nodeExtraOptions, ...options })
 
       this.createNodeRefs(node, actions)
     }))


### PR DESCRIPTION
Allow adding extra options to the imported nodes.
I think is helpful to tag nodes in the same collections but imported from different folders, making it easy to organize the content in different folders.

In my use case, I have a collection called "Event" with 3 different types (tag), and instead of tag every single node, is more convenient to store every type in a different folder and use this modification to tag all at the same time.
