### PR TITLE
feat(makePath): use raw string as a fallback when the slugify result is empty

### DIFF
--- a/gridsome/lib/plugins/TemplatesPlugin.js
+++ b/gridsome/lib/plugins/TemplatesPlugin.js
@@ -65,9 +65,12 @@ const makePath = (object, { path, routeKeys, createPath }, dateField = 'date', s
         ) {
           return String(value.id)
         } else if (!isPlainObject(value)) {
-          return suffix === 'raw'
-            ? String(value)
-            : slugify(String(value))
+          const slugifyValue = slugify(String(value))
+          if (suffix === 'raw' || slugifyValue === '') {
+            return String(value)
+          } else {
+            return slugifyValue
+          }
         } else {
           return ''
         }


### PR DESCRIPTION
## Why

When we use CJK characters as the routing path, gridsome returns an error because slugify result is an empty string that cannot be used as the routing path.

Although the URL without slugify may not be beautiful, users generally prefer to build successfully first and then look for a solution likes to add `slug` in the markdown file or use `:fileInfo__name` as route path if they are not satisfied with the encoded URL. (Relate issues #918, #956)

## My test

```
// case 1 (raw title fallback)
title: '테스트'
result: http://example.com/%ED%85%8C%EC%8A%A4%ED%8A%B8/

// case 2 (raw title fallback)
title: '中文测试'
result: http://example.com/%E4%B8%AD%E6%96%87%E6%B5%8B%E8%AF%95/

// case 3 (affected by slugify)
title: 'test 中文测试'
result: http://example.com/test/

// case 4
title: 'slugify() test'
result: http://example.com/slugify-test/
```
