### PR TITLE
Optional srcset&sizes for custom g-image

### DIFF
--- a/gridsome/app/components/Image.js
+++ b/gridsome/app/components/Image.js
@@ -43,7 +43,7 @@ export default {
         attrs.height = size.height
 
         if (isLazy) attrs['data-src'] = src
-        if (srcset.length) attrs[`${isLazy ? 'data-' : ''}srcset`] = Array.isArray(srcset) ? srcset.join(', ') : srcset
+        if (srcset && srcset.length) attrs[`${isLazy ? 'data-' : ''}srcset`] = Array.isArray(srcset) ? srcset.join(', ') : srcset
         if (sizes) attrs[`${isLazy ? 'data-' : ''}sizes`] = sizes
 
         if (isLazy) {

--- a/gridsome/app/directives/image.js
+++ b/gridsome/app/directives/image.js
@@ -83,7 +83,7 @@ function loadImage (el) {
     addClass(el, 'g-image--error')
   }
 
-  el.srcset = srcset
-  el.sizes = sizes
+  if (srcset) el.srcset = srcset
+  if (sizes) el.sizes = sizes
   el.src = src
 }


### PR DESCRIPTION
See issue https://github.com/gridsome/gridsome/issues/1295#issuecomment-753877204

& the need for a lazy-loaded image where one might not have different sizes available:

```vue
<g-image :src="{
    src: 'https://picsum.photos/200/300',
    size: {width: 200, height: 300},
    dataUri: 'data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=', // http://probablyprogramming.com/2009/03/15/the-tiniest-gif-ever
}" />
```