### PR TITLE
Enable loading `.env.local` and `.env.*.local`

### DIFF
--- a/gridsome/lib/app/loadConfig.js
+++ b/gridsome/lib/app/loadConfig.js
@@ -211,22 +211,33 @@ function registerTsExtension() {
   }
 }
 
-function resolveEnv (context) {
-  const env = process.env.NODE_ENV || 'development'
-  const envPath = path.resolve(context, '.env')
-  const envPathByMode = path.resolve(context, `.env.${env}`)
-  const readPath = fs.existsSync(envPathByMode) ? envPathByMode : envPath
+function resolveEnv(context) {
+  const mode = process.env.NODE_ENV || 'development'
+  const envFiles = [
+    /** default file */ `.env`,
+    /** local file */ `.env.local`,
+    /** mode file */ `.env.${mode}`,
+    /** mode local file */ `.env.${mode}.local`
+  ].map(p => path.resolve(context, p))
 
-  let parsed = {}
-  try {
-    parsed = dotenv.parse(fs.readFileSync(readPath, 'utf8'))
-  } catch (err) {
-    if (err.code !== 'ENOENT') {
-      console.error('There was a problem processing the .env file', err)
+  const variables = {}
+
+  for (const file of envFiles) {
+    try {
+      const parsed = dotenv.parse(fs.readFileSync(file), {
+        debug: !!process.env.DEBUG || undefined
+      })
+
+      Object.assign(variables, parsed)
+    } catch (err) {
+      if (err.code !== 'ENOENT')
+        console.error(`There was a problem processing the ${file} file`, err)
     }
   }
 
-  return parsed
+  // Existing environment variables have precedence
+  // https://12factor.net/config
+  return Object.assign(variables, process.env)
 }
 
 function resolvePkg (context) {


### PR DESCRIPTION
Loads `.env.local` and environment-specific `.env.${NODE_ENV}.local`.

Also merges variables from multiple `.env.*` files with the base `.env`, similar to other tools like Vite and Vue CLI. (See  #1332)

Follows this order of precedence:
1. Existing env vars (since they're likely deployment-specific)
2. `.env.${NODE_ENV}.local`
3. `.env.${NODE_ENV}`
4. `.env.local`
5. `.env`

Implementation was based on [Vite's config](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/config.ts#L974-L1034)