### PR TITLE
Fix transformer-remark visit

### DIFF
--- a/packages/transformer-remark/lib/plugins/file.js
+++ b/packages/transformer-remark/lib/plugins/file.js
@@ -9,7 +9,7 @@ module.exports = function attacher () {
 
     const links = []
 
-    visit(tree, 'link', node => links.push(node))
+    visit(tree, 'link', node => { links.push(node) })
 
     for (const node of links) {
       const path = file.data.node

--- a/packages/transformer-remark/lib/plugins/image.js
+++ b/packages/transformer-remark/lib/plugins/image.js
@@ -9,7 +9,7 @@ module.exports = function attacher (options = {}) {
 
     const images = []
 
-    visit(tree, 'image', node => images.push(node))
+    visit(tree, 'image', node => { images.push(node) })
 
     for (const node of images) {
       const data = node.data || {}


### PR DESCRIPTION
The return value matters for the visitor function. This bug was causing some images and links to be skipped when parsing the remark AST. The result was that images would show up as `img` with a invalid src value instead of `g-image`.

https://github.com/syntax-tree/unist-util-visit-parents#returns
