### PR TITLE
fix error on build with source-strapi plugin

### DIFF
--- a/packages/source-strapi/index.js
+++ b/packages/source-strapi/index.js
@@ -37,10 +37,11 @@ module.exports = function (api, options) {
         const collection = addCollection({ typeName, dateField: 'created_at' })
         const isSingleType = false
         return query({ apiURL, resourceName, jwtToken, queryLimit, isSingleType })
-          .then(docs => docs.forEach(doc => {
-            collection.addNode(doc)
+          .then(docs => {
+            for (const docKey in docs) {
+              collection.addNode(docs[docKey])
+            }
           })
-          )
       })),
       Promise.all(singleTypes.map(resourceName => {
         const typeName = upperFirst(camelCase(`${options.typeName} ${resourceName}`))


### PR DESCRIPTION
Hello. 
I have the same error of [the issue #1590](https://github.com/gridsome/gridsome/issues/1590)

The error: 
```
Initializing plugins...
Fetching data from Strapi (http://localhost:1337/api)
TypeError: docs.forEach is not a function
```

The plugin iterates with forEach on docs but it is an object type.
It is resolved for me with an "for in" iteration.