### PR TITLE
add config option to disable the content hash for image processing

### DIFF
--- a/gridsome/lib/app/queue/ImageProcessQueue.js
+++ b/gridsome/lib/app/queue/ImageProcessQueue.js
@@ -244,7 +244,11 @@ class ImageProcessQueue {
     const optionsHash = genHash(string).substr(0, 7)
     const contentHash = !process.env.GRIDSOME_TEST ? hash : 'test'
 
-    return `${name}.${optionsHash}.${contentHash}${ext}`
+    if (typeof this.config.images.contentHash === 'boolean' && !this.config.images.contentHash) {
+      return `${name}.${optionsHash}${ext}`
+    } else {
+      return `${name}.${optionsHash}.${contentHash}${ext}`
+    }
   }
 }
 


### PR DESCRIPTION
We've been running into deploy issues where the image filename sizes are too long, being able to remove the content hash for processed images would be helpful in getting around the deployment issues.