### PR TITLE
Check for undefined data in source-drupal

### DIFF
--- a/packages/source-drupal/lib/Entity.js
+++ b/packages/source-drupal/lib/Entity.js
@@ -146,6 +146,7 @@ class Entity {
   }
 
   createReference (data) {
+    if (!data) return;
     const { createReference } = this.actions
     const typeName = this.createTypeName(data.type)
 


### PR DESCRIPTION
I am trying to create a field in Drupal that references a content type but the build fails with the error `TypeError: Cannot read properties of undefined (reading 'type') at [Entity.createReference](https://entity.createreference/) (/app/front/node_modules/@gridsome/source-drupal/lib/Entity.js:150:47)`.

This seems to be happening because the `processRelationships` function in the source-drupal package checks whether data is `null` but doesn't check whether it's `undefined`. This causes the build to fail when data is `undefined`. 